### PR TITLE
Add task status cycling

### DIFF
--- a/crates/otui-core/src/markdown.rs
+++ b/crates/otui-core/src/markdown.rs
@@ -65,8 +65,9 @@ pub enum BlockKind {
 pub enum Marker {
     Bullet,
     Ordered(u64),
-    /// A `- [ ]` / `- [x]` task; `true` when checked.
-    Task(bool),
+    /// A `- [ ]` / `- [x]` task; the char is what's inside the brackets
+    /// (`' '` unchecked, `'x'` done, `/`, `-`, `!`, …).
+    Task(char),
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -377,7 +378,7 @@ fn list_item(line: &str) -> Option<(usize, Marker, &str)> {
                 if task.len() >= 2 && task.as_bytes()[1] == b']' {
                     let state = task.as_bytes()[0];
                     let text = task[2..].strip_prefix(' ').unwrap_or(&task[2..]);
-                    return Some((depth, Marker::Task(state != b' ' && state != b'\t'), text));
+                    return Some((depth, Marker::Task(state as char), text));
                 }
             }
             return Some((depth, Marker::Bullet, rest));
@@ -818,8 +819,29 @@ mod tests {
         assert_eq!(items[0], (0, Marker::Bullet, "one".into()));
         assert_eq!(items[1], (1, Marker::Bullet, "nested".into()));
         assert_eq!(items[2], (0, Marker::Ordered(1), "first".into()));
-        assert_eq!(items[3], (0, Marker::Task(false), "todo".into()));
-        assert_eq!(items[4], (0, Marker::Task(true), "done".into()));
+        assert_eq!(items[3], (0, Marker::Task(' '), "todo".into()));
+        assert_eq!(items[4], (0, Marker::Task('x'), "done".into()));
+    }
+
+    #[test]
+    fn preserves_custom_task_status_chars() {
+        let doc = parse_body("- [/] in progress\n- [!] important\n- [-] cancelled\n", 0);
+        let items: Vec<(usize, Marker, String)> = doc
+            .blocks
+            .iter()
+            .filter_map(|b| match &b.kind {
+                BlockKind::ListItem {
+                    depth,
+                    marker,
+                    spans,
+                } => Some((*depth, *marker, spans_to_text(spans))),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(items[0], (0, Marker::Task('/'), "in progress".into()));
+        assert_eq!(items[1], (0, Marker::Task('!'), "important".into()));
+        assert_eq!(items[2], (0, Marker::Task('-'), "cancelled".into()));
     }
 
     #[test]

--- a/crates/otui/src/actions.rs
+++ b/crates/otui/src/actions.rs
@@ -60,6 +60,14 @@ pub fn commands() -> Vec<Entry> {
         Entry::new("Reload vault from disk", "", Action::Refresh),
         Entry::new("Save settings to config file", "", Action::SaveSettings),
         Entry::new("Keyboard shortcuts", "?", Action::OpenHelp),
+        // ---- tasks ------------------------------------------------------
+        Entry::new("Cycle task status", "Alt+Enter", Action::CycleTask),
+        Entry::new(
+            "Cycle task status (reverse)",
+            "Alt+Shift+Enter",
+            Action::CycleTaskReverse,
+        ),
+        Entry::new("Mark task as…", "", Action::MarkTask),
         Entry::new("Quit", "q", Action::Quit),
     ]
 }
@@ -85,6 +93,55 @@ fn cycle_sort_order(app: &mut App) {
         app.explorer.scroll_into_view(area.height as usize);
     }
     app.info(format!("sorted by {}; /config keeps it", next.label()));
+}
+
+/// Advances (or reverses) the task status of the current line / selection
+/// through the configured cycle.
+fn cycle_task(app: &mut App, reverse: bool) {
+    let cycle: Vec<char> = app.config.editor.task_cycle.chars().collect();
+    if cycle.len() < 2 {
+        return;
+    }
+    let Some(editor) = app.editor_mut() else {
+        app.error("open a note in editing mode first");
+        return;
+    };
+    let changed = editor.transform_tasks(|ch| {
+        let pos = cycle.iter().position(|&c| c == ch).unwrap_or(0);
+        let next = if reverse {
+            (pos + cycle.len() - 1) % cycle.len()
+        } else {
+            (pos + 1) % cycle.len()
+        };
+        cycle[next]
+    });
+    if !changed {
+        app.info("no task on this line");
+    }
+}
+
+/// Sets the task status directly.
+fn set_task_status(app: &mut App, status: char) {
+    let Some(editor) = app.editor_mut() else {
+        app.error("open a note in editing mode first");
+        return;
+    };
+    let changed = editor.transform_tasks(|_| status);
+    if !changed {
+        app.info("no task on this line");
+    }
+}
+
+/// Opens the "Mark task as…" picker listing every configured status.
+fn mark_task_prompt(app: &mut App) {
+    let entries: Vec<Entry> = app
+        .config
+        .editor
+        .task_cycle
+        .chars()
+        .map(|ch| Entry::new(format!("[{}]", ch), "", Action::MarkTaskAs(ch)))
+        .collect();
+    app.modal = Some(Modal::Picker(Picker::new(PickerKind::TaskStatus, entries)));
 }
 
 fn open_in_obsidian(app: &mut App) {
@@ -297,6 +354,12 @@ pub fn dispatch(app: &mut App, action: Action) {
                 Focus::Note
             };
         }
+
+        // ---- tasks ------------------------------------------------------
+        Action::CycleTask => cycle_task(app, false),
+        Action::CycleTaskReverse => cycle_task(app, true),
+        Action::MarkTask => mark_task_prompt(app),
+        Action::MarkTaskAs(status) => set_task_status(app, status),
 
         // ---- modals -----------------------------------------------------
         Action::OpenPalette => {
@@ -747,5 +810,81 @@ mod tests {
         dispatch(&mut app, Action::ToggleGraphUnresolved);
         let after = app.graph.as_ref().unwrap().simulation.graph.nodes.len();
         assert_ne!(before, after, "hiding unresolved notes changes the graph");
+    }
+
+    // ---- task cycling ----------------------------------------------------
+
+    /// Writes a task note into the index and opens it for editing, with the
+    /// cursor on line 0 (the task line).
+    fn open_task_note(app: &mut App, content: &str) {
+        let id = app.index.create_note("Tasks", content).expect("note");
+        app.open_note(id);
+        app.active_mut().unwrap().mode = Mode::Editing;
+    }
+
+    #[test]
+    fn cycling_a_task_advances_through_the_cycle() {
+        let (_v, mut app) = app();
+        open_task_note(&mut app, "- [ ] todo\n");
+
+        dispatch(&mut app, Action::CycleTask);
+        assert_eq!(app.editor_mut().unwrap().text(), "- [/] todo\n");
+
+        dispatch(&mut app, Action::CycleTask);
+        assert_eq!(app.editor_mut().unwrap().text(), "- [x] todo\n");
+
+        dispatch(&mut app, Action::CycleTask);
+        assert_eq!(app.editor_mut().unwrap().text(), "- [ ] todo\n", "wraps");
+    }
+
+    #[test]
+    fn cycling_reverse_goes_backward() {
+        let (_v, mut app) = app();
+        open_task_note(&mut app, "- [ ] todo\n");
+
+        dispatch(&mut app, Action::CycleTaskReverse);
+        assert_eq!(
+            app.editor_mut().unwrap().text(),
+            "- [x] todo\n",
+            "reverse wraps back to the last status"
+        );
+    }
+
+    #[test]
+    fn mark_task_as_sets_a_specific_status() {
+        let (_v, mut app) = app();
+        open_task_note(&mut app, "- [ ] todo\n");
+
+        dispatch(&mut app, Action::MarkTaskAs('!'));
+        assert_eq!(app.editor_mut().unwrap().text(), "- [!] todo\n");
+    }
+
+    #[test]
+    fn mark_task_opens_the_status_picker() {
+        let (_v, mut app) = app();
+        dispatch(&mut app, Action::MarkTask);
+
+        match app.modal.as_ref() {
+            Some(Modal::Picker(picker)) => {
+                assert_eq!(picker.kind, PickerKind::TaskStatus);
+                let labels: Vec<&str> = picker.visible().map(|(e, _)| e.label.as_str()).collect();
+                assert_eq!(labels, vec!["[ ]", "[/]", "[x]"]);
+            }
+            other => panic!("expected a task-status picker, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cycling_a_non_task_line_reports_it() {
+        let (_v, mut app) = app();
+        open_task_note(&mut app, "plain text\n");
+
+        dispatch(&mut app, Action::CycleTask);
+        assert!(
+            app.status.text.contains("no task"),
+            "expected a message, got {:?}",
+            app.status.text
+        );
+        assert_eq!(app.editor_mut().unwrap().text(), "plain text\n");
     }
 }

--- a/crates/otui/src/app.rs
+++ b/crates/otui/src/app.rs
@@ -197,6 +197,17 @@ pub enum Action {
     OpenLocalGraph,
     OpenNotesView,
 
+    // Tasks
+    /// Advance the current task (or every task in the selection) to the next
+    /// status in `config.editor.task_cycle`.
+    CycleTask,
+    /// Same, but backwards.
+    CycleTaskReverse,
+    /// Open the "Mark task as…" picker.
+    MarkTask,
+    /// Set the task status character directly.
+    MarkTaskAs(char),
+
     // Modals
     OpenPalette,
     OpenSwitcher,

--- a/crates/otui/src/config.rs
+++ b/crates/otui/src/config.rs
@@ -113,6 +113,9 @@ pub struct EditorConfig {
     pub daily_folder: String,
     /// `chrono`-free date format for daily notes: `%Y`, `%m`, `%d` only.
     pub daily_format: String,
+    /// Ordered task statuses for Alt+Enter cycling (first char = unchecked).
+    /// E.g. " /x" cycles `[ ]` → `[/]` → `[x]` → `[ ]`.
+    pub task_cycle: String,
 }
 
 impl Default for EditorConfig {
@@ -125,6 +128,7 @@ impl Default for EditorConfig {
             new_note_folder: String::new(),
             daily_folder: "Daily".into(),
             daily_format: "%Y-%m-%d".into(),
+            task_cycle: " /x".into(),
         }
     }
 }
@@ -386,6 +390,21 @@ mod tests {
         let parsed: Config = toml::from_str(&text).expect("parse");
         assert_eq!(parsed.theme, "gruvbox-dark");
         assert_eq!(parsed.ui.chat_width, config.ui.chat_width);
+    }
+
+    #[test]
+    fn task_cycle_round_trips_through_toml() {
+        let config = Config {
+            editor: EditorConfig {
+                task_cycle: " /x-".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let text = toml::to_string_pretty(&config).expect("serialize");
+        let parsed: Config = toml::from_str(&text).expect("parse");
+        assert_eq!(parsed.editor.task_cycle, " /x-");
+        assert_eq!(parsed.editor.task_cycle, config.editor.task_cycle);
     }
 
     #[test]

--- a/crates/otui/src/editor.rs
+++ b/crates/otui/src/editor.rs
@@ -401,6 +401,35 @@ impl Editor {
         self.modified = true;
     }
 
+    /// Applies `f` to the status char of every task line in the selection (or the
+    /// cursor line when there's no selection). Returns true if any line changed.
+    pub fn transform_tasks(&mut self, mut f: impl FnMut(char) -> char) -> bool {
+        let (start, end) = match self.selection() {
+            Some((a, b)) => (a.line, b.line),
+            None => (self.cursor.line, self.cursor.line),
+        };
+        let mut changed = false;
+        for line in start..=end {
+            if let Some((open, status, close)) = task_marker(&self.lines[line]) {
+                let next = f(status);
+                if next == status {
+                    continue;
+                }
+                if !changed {
+                    self.push_undo(EditKind::Structural);
+                    changed = true;
+                }
+                let mut updated = self.lines[line].clone();
+                updated.replace_range(open..close, &format!("[{next}]"));
+                self.lines[line] = updated;
+            }
+        }
+        if changed {
+            self.modified = true;
+        }
+        changed
+    }
+
     pub fn delete_selection(&mut self) {
         if self.selection().is_some() {
             self.push_undo(EditKind::Delete);
@@ -609,6 +638,39 @@ fn split_lines(text: &str) -> Vec<String> {
     lines
 }
 
+/// Returns `(open, status, close)` byte indices covering `[<status>]` if the
+/// line is a task line: optional ASCII whitespace, `-`/`*`/`+`, a space, then
+/// `[c]`. `open` points at `[`, `close` is one past `]`. A single status char
+/// is required; `[]`, `[ab]`, or a tab after the bullet are not tasks.
+fn task_marker(line: &str) -> Option<(usize, char, usize)> {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    // Skip ASCII whitespace (space/tab) ahead of the bullet.
+    while i < bytes.len() && matches!(bytes[i], b' ' | b'\t') {
+        i += 1;
+    }
+    if i >= bytes.len() || !matches!(bytes[i], b'-' | b'*' | b'+') {
+        return None;
+    }
+    // Mirror the core parser: exactly one space after the bullet, never a tab.
+    let open = i + 2;
+    if open >= bytes.len() || bytes[open - 1] != b' ' || bytes[open] != b'[' {
+        return None;
+    }
+    let close_rel = line[open..].find(']')?;
+    let close = open + close_rel + 1; // one past `]`
+    let status_slice = &line[open + 1..close - 1];
+    if status_slice.is_empty() {
+        return None;
+    }
+    let mut chars = status_slice.chars();
+    let status = chars.next()?;
+    if chars.next().is_some() {
+        return None;
+    }
+    Some((open, status, close))
+}
+
 #[cfg(test)]
 impl Editor {
     /// Test helper: move the cursor while extending the selection.
@@ -766,6 +828,73 @@ mod tests {
         ed.delete_line();
         assert_eq!(ed.text(), "one\nthree\n");
         assert_eq!(ed.cursor().line, 1);
+    }
+
+    #[test]
+    fn transform_tasks_cycles_status_forward_with_wrap() {
+        let mut ed = editor("- [ ] one\n- [x] two\n");
+        let advanced = ed.transform_tasks(|c| match c {
+            ' ' => '/',
+            '/' => 'x',
+            'x' => ' ',
+            other => other,
+        });
+        assert!(advanced);
+        assert_eq!(ed.text(), "- [/] one\n- [x] two\n", "cursor line only");
+    }
+
+    #[test]
+    fn transform_tasks_cycles_status_backward_with_wrap() {
+        let mut ed = editor("- [ ] one");
+        let advanced = ed.transform_tasks(|c| match c {
+            ' ' => 'x',
+            '/' => ' ',
+            'x' => '/',
+            other => other,
+        });
+        assert!(advanced);
+        assert_eq!(ed.text(), "- [x] one\n", "wraps back to the last state");
+    }
+
+    #[test]
+    fn transform_tasks_sets_status_directly() {
+        let mut ed = editor("- [x] done");
+        assert!(ed.transform_tasks(|_| ' '));
+        assert_eq!(ed.text(), "- [ ] done\n");
+    }
+
+    #[test]
+    fn transform_tasks_skips_plain_bullet_lines_in_a_selection() {
+        let mut ed = editor("- [ ] a\n- plain\n");
+        ed.goto(0, 0);
+        ed.begin_selection();
+        ed.goto_extend(1, 3);
+        assert!(ed.transform_tasks(|c| if c == ' ' { 'x' } else { c }));
+        assert_eq!(ed.text(), "- [x] a\n- plain\n", "plain line untouched");
+    }
+
+    #[test]
+    fn transform_tasks_on_a_non_task_line_is_a_no_op() {
+        let mut ed = editor("just text\n");
+        assert!(!ed.transform_tasks(|c| c));
+        assert_eq!(ed.text(), "just text\n");
+    }
+
+    #[test]
+    fn transform_tasks_is_a_single_undo_step() {
+        let mut ed = editor("- [ ] one\n- [x] two\n");
+        ed.goto(0, 0);
+        ed.begin_selection();
+        ed.goto_extend(1, 0);
+        ed.transform_tasks(|c| if c == ' ' { 'x' } else { ' ' });
+        assert_eq!(ed.text(), "- [x] one\n- [ ] two\n");
+
+        assert!(ed.undo());
+        assert_eq!(
+            ed.text(),
+            "- [ ] one\n- [x] two\n",
+            "one undo restores every line in the operation"
+        );
     }
 
     #[test]

--- a/crates/otui/src/keys.rs
+++ b/crates/otui/src/keys.rs
@@ -317,6 +317,7 @@ fn follow_first_link(app: &mut App) {
 fn handle_editing(app: &mut App, key: KeyEvent) {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
 
     // Formatting shortcuts are checked before the editor sees the key.
     if ctrl {
@@ -362,6 +363,20 @@ fn handle_editing(app: &mut App, key: KeyEvent) {
                 if let Some(editor) = app.editor_mut() {
                     editor.delete_line();
                 }
+                return;
+            }
+            _ => {}
+        }
+    }
+
+    if alt {
+        match key.code {
+            KeyCode::Enter if !shift => {
+                dispatch(app, Action::CycleTask);
+                return;
+            }
+            KeyCode::Enter if shift => {
+                dispatch(app, Action::CycleTaskReverse);
                 return;
             }
             _ => {}
@@ -713,6 +728,35 @@ mod tests {
 
         handle(&mut app, key(KeyCode::Esc));
         assert_eq!(app.active().unwrap().mode, Mode::Reading);
+    }
+
+    #[test]
+    fn alt_enter_cycles_a_task() {
+        let (_v, mut app) = app();
+        let id = app.index.create_note("Tasks", "- [ ] todo\n").unwrap();
+        app.open_note(id);
+        app.active_mut().unwrap().mode = Mode::Editing;
+
+        handle(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT));
+        assert_eq!(app.editor_mut().unwrap().text(), "- [/] todo\n");
+    }
+
+    #[test]
+    fn alt_shift_enter_cycles_reverse() {
+        let (_v, mut app) = app();
+        let id = app.index.create_note("Tasks", "- [x] done\n").unwrap();
+        app.open_note(id);
+        app.active_mut().unwrap().mode = Mode::Editing;
+
+        handle(
+            &mut app,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT | KeyModifiers::SHIFT),
+        );
+        assert_eq!(
+            app.editor_mut().unwrap().text(),
+            "- [/] done\n",
+            "reverse goes x → / through the cycle"
+        );
     }
 
     #[test]

--- a/crates/otui/src/modal.rs
+++ b/crates/otui/src/modal.rs
@@ -17,6 +17,7 @@ pub enum PickerKind {
     Themes,
     Vaults,
     Search,
+    TaskStatus,
 }
 
 impl PickerKind {
@@ -28,6 +29,7 @@ impl PickerKind {
             Self::Themes => "Themes",
             Self::Vaults => "Open vault",
             Self::Search => "Search",
+            Self::TaskStatus => "Mark task as…",
         }
     }
 
@@ -39,6 +41,7 @@ impl PickerKind {
             Self::Themes => "Filter themes…",
             Self::Vaults => "Filter vaults…",
             Self::Search => "Search all notes…",
+            Self::TaskStatus => "Filter statuses…",
         }
     }
 }

--- a/crates/otui/src/ui/mod.rs
+++ b/crates/otui/src/ui/mod.rs
@@ -38,7 +38,6 @@ pub mod icons {
     pub const SETTINGS: &str = "⚙";
     pub const BULLET: &str = "•";
     pub const QUOTE_BAR: &str = "▎";
-    pub const TASK_DONE: &str = "☑";
     pub const TASK_TODO: &str = "☐";
     pub const SCROLL_THUMB: &str = "│";
 }

--- a/crates/otui/src/ui/note.rs
+++ b/crates/otui/src/ui/note.rs
@@ -268,19 +268,19 @@ fn render_block(
                     Style::default().fg(palette.list_marker),
                 ),
                 Marker::Ordered(n) => (format!("{n}."), Style::default().fg(palette.list_marker)),
-                Marker::Task(true) => (
-                    icons::TASK_DONE.to_string(),
-                    Style::default().fg(palette.checkbox_done),
-                ),
-                Marker::Task(false) => (
+                Marker::Task(ch) if *ch == ' ' => (
                     icons::TASK_TODO.to_string(),
                     Style::default().fg(palette.checkbox_todo),
+                ),
+                Marker::Task(ch) => (
+                    format!("[{}]", ch),
+                    Style::default().fg(palette.checkbox_done),
                 ),
             };
 
             let mut styled = style_spans(spans, palette, index);
             // Completed tasks are struck through, as in Obsidian.
-            if matches!(marker, Marker::Task(true)) {
+            if matches!(marker, Marker::Task('x')) {
                 for (_, style) in &mut styled {
                     *style = style
                         .add_modifier(Modifier::CROSSED_OUT)
@@ -989,18 +989,34 @@ mod tests {
         let index = vault.index();
         let palette = palette();
 
-        let document = markdown::parse("- [ ] todo\n- [x] done\n");
+        let document = markdown::parse("- [ ] todo\n- [x] done\n- [/] in progress\n");
         let lines = render_document(&document, &palette, &index, 40);
         let rendered = text_of(&lines);
 
         assert!(rendered.iter().any(|l| l.contains(icons::TASK_TODO)));
-        assert!(rendered.iter().any(|l| l.contains(icons::TASK_DONE)));
+        assert!(rendered.iter().any(|l| l.contains("[x]")));
+        assert!(rendered.iter().any(|l| l.contains("[/]")));
 
         let done_line = lines
             .iter()
             .find(|l| l.spans.iter().any(|s| s.content.contains("done")))
             .expect("done line");
         assert!(done_line
+            .spans
+            .iter()
+            .any(|s| s.style.add_modifier.contains(Modifier::CROSSED_OUT)));
+
+        let progress_line = lines
+            .iter()
+            .find(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+                    .contains("in progress")
+            })
+            .expect("in progress line");
+        assert!(!progress_line
             .spans
             .iter()
             .any(|s| s.style.add_modifier.contains(Modifier::CROSSED_OUT)));


### PR DESCRIPTION
## What

Adds task status cycling to the editor:

- Alt+Enter cycles the current line (or every task line in the selection) through the configured status cycle. Default: `[ ]` → `[/]` → `[x]` → `[ ]`.
- Alt+Shift+Enter cycles backward.
- Command palette: "Mark task as..." opens a picker to jump directly to any status (for example `[!]`, `[-]`, `[?]`).
- New `[editor] task_cycle` config option sets the cycle order, e.g. `task_cycle = " /x-?!"`.
- Reading view now renders each status as its bracket character (`[/]`, `[!]`, ...); strikethrough is reserved for completed `x` tasks.

## Why

Obsidian task workflows commonly use intermediate statuses beyond done/undone. This brings obsidian-tui's task handling closer to Obsidian's Task Marker plugin and ITS theme alternate checkboxes, without requiring the GUI app.

## Implementation notes

- `Marker::Task(bool)` in the core parser is now `Marker::Task(char)`, preserving the character inside `[ ]`.
- One editor method, `Editor::transform_tasks`, rewrites statuses across the selection or current line as a single undo step.
- No new dependencies. All existing tests pass (488 workspace tests), clippy clean, fmt clean.

## Testing

A draft release with a Linux x86_64 test binary is available here: https://github.com/jelloeater-agent/obsidian-tui/releases/tag/untagged-91f8bc4d1cad75d4002a. Otherwise: `cargo build --release` then run `./target/release/obsidian-tui`, open a note with tasks, and press Alt+Enter in editing mode.

## Checklist

- [ ] Tests pass (`cargo test --workspace`)
- [ ] clippy clean
- [ ] fmt clean
- [ ] CHANGELOG entry (maintainer may add at release time)

