### PR TITLE
Release 0.3.0: an editor you can actually write in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,79 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-08-05
+
+The release that makes the editor usable for actually writing in: text wraps,
+the cursor goes where it looks like it goes, and Markdown is styled while you
+type it instead of only once you stop.
+
+### Added
+
+- **Long lines wrap while editing.** A line wider than the pane used to be cut
+  off at the edge, and since the editor had no way to pan sideways either, the
+  rest of it was not merely hidden but unreachable. `editor.wrap` has been in the
+  config file since the first release, documented as doing exactly this, and was
+  read by nothing; it now works, and setting it to `false` genuinely pans instead.
+  A wrapped row is marked with a `⤷` in the gutter, so a soft wrap is still
+  distinguishable from a real line break, and a wrapped list item is indented to
+  sit under its own text rather than under its bullet.
+- The arrow keys, `Home`, `End` and `PageUp`/`PageDown` move by the rows on
+  screen rather than by lines in the file. On a paragraph that fills four rows,
+  four presses of `Down` cross it — which is what every other editor does, and
+  the only behavior that makes sense once text wraps.
+- **Markdown is styled while you edit it**, the way Obsidian's live preview
+  styles it: headings coloured and bold, bullets drawn as `•`, task boxes as
+  `[☑]`, quotes as `▎`, and bold, italic, code, links, tags and `==highlights==`
+  in the same colours the reading pane uses. Nothing is hidden and nothing moves:
+  every glyph substituted in is exactly as wide as the character it stands for,
+  which is what keeps the caret exactly where the character is. The line the
+  cursor is on shows its syntax at full contrast, so what you edit is what you
+  see, and because the widths match, the text does not shift as the cursor
+  arrives or leaves. A fenced code block is drawn on its own background and its
+  contents are never read as Markdown.
+- **Clicking places the cursor, and dragging selects.** Both are resolved against
+  the text as it was actually drawn, so they land on the character under the
+  pointer however the line wrapped.
+- **`Enter` continues a list.** `- `, `* `, `1. ` and `- [ ] ` carry down to the
+  next line, an ordered list counts up, and a task always starts unchecked —
+  carrying "done" onto a line nobody has done yet would be a lie. Pressing it on
+  an item with nothing on it ends the list, which is how you stop.
+- **`Tab` and `Shift+Tab` nest and unnest a list item**, or indent every line of
+  a selection. In prose `Tab` is still a tab. `Shift+Tab` did nothing at all
+  before.
+- The status bar shows `Ln 12/40, Col 3` while editing, and how many characters
+  are selected.
+
+### Fixed
+
+- **The mouse wheel now scrolls while editing.** It was writing to the reading
+  view's scroll offset, which the editor never reads, so it silently did nothing.
+- The caret was positioned by counting characters and then clamped to the pane,
+  so on a long line it parked at the right margin and lied about where it was,
+  and on CJK or emoji text — where one character is two columns wide — it was in
+  the wrong place on any line containing one.
+- **`Ctrl+E` no longer reflows the note.** Reading laid prose out from the pane's
+  left edge while editing started it after the line-number gutter, so the two
+  modes wrapped the same paragraph to different widths and every line broke
+  somewhere else on the way in and out of the editor. The gutter's width is now
+  reserved in both modes — blank while reading — so switching restyles the page
+  without moving a word of it. It costs four columns of reading width, and
+  nothing at all when line numbers are switched off.
+- The scrollbar counted lines rather than rows, so it misreported how far through
+  a note with any wrapped lines in it you were.
+- The cursor line's highlight and a code block's background now reach the edge of
+  the pane instead of stopping wherever the text happened to end.
+- A caret was drawn in the note pane even when the keyboard belonged to the chat
+  panel or the file explorer.
+- The editor no longer scrolls past the end of a note that would fit on screen.
+- **The outline scrolled to the wrong place.** Picking a heading set the reading
+  view's scroll offset to the heading's line number in the file, but that offset
+  counts *rendered rows* — and prose wraps, headings gain a rule under them and a
+  picture takes a dozen rows, so the two numbers drift further apart the further
+  down the note you go. The draw pass now writes down which row each block landed
+  on, the same way it already records where it put every picture, and the jump is
+  translated through it.
+
 ### Changed
 
 - **Moved to the 2024 edition**, stable since Rust 1.85 and comfortably under
@@ -289,6 +362,7 @@ First release.
 - Unreadable vaults are reported clearly, including the macOS privacy
   permission that usually causes it.
 
+[0.3.0]: https://github.com/iamrohithrnair/obsidian-tui/releases/tag/v0.3.0
 [0.2.0]: https://github.com/iamrohithrnair/obsidian-tui/releases/tag/v0.2.0
 [0.1.2]: https://github.com/iamrohithrnair/obsidian-tui/releases/tag/v0.1.2
 [0.1.1]: https://github.com/iamrohithrnair/obsidian-tui/releases/tag/v0.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "otui"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "otui-agent"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "otui-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "otui-theme"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ratatui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/otui-core", "crates/otui-theme", "crates/otui-agent", "crates/otui"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 # Set by the dependency chain, not by this code: ratatui-image pulls
 # icy_sixel, which pins quantette 0.5.1, which requires 1.90.
@@ -15,9 +15,9 @@ keywords = ["obsidian", "tui", "notes", "markdown", "graph"]
 categories = ["command-line-utilities", "text-editors"]
 
 [workspace.dependencies]
-otui-core = { path = "crates/otui-core", version = "0.2.0" }
-otui-theme = { path = "crates/otui-theme", version = "0.2.0" }
-otui-agent = { path = "crates/otui-agent", version = "0.2.0" }
+otui-core = { path = "crates/otui-core", version = "0.3.0" }
+otui-theme = { path = "crates/otui-theme", version = "0.3.0" }
+otui-agent = { path = "crates/otui-agent", version = "0.3.0" }
 
 ratatui = "0.30"
 crossterm = "0.29"

--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ doesn't. `?` shows the full list in the app.
 | `hjkl`, `g`, `G` | Move within a pane |
 | `Enter` | Open / follow a link |
 
+In the editor: `↑`/`↓`, `Home` and `End` follow the rows on screen, so a wrapped
+paragraph moves through a line at a time as it looks rather than as it is stored.
+`Enter` carries a list marker onto the next line and ends the list when you press
+it on an empty item; `Tab`/`Shift+Tab` nest and unnest a list item, and are still
+a tab in prose. `Ctrl+B`/`Ctrl+I` wrap the selection, `Ctrl+Space` starts one
+without holding `Shift`, and `Ctrl+Shift+K` deletes the line.
+
 In the file explorer: `/` filters by name, `s` changes the sort order, `Space`
 folds a folder, and `H`/`L` collapse or expand every folder at once.
 
@@ -165,6 +172,7 @@ The ribbon icons are buttons, and most of the UI is clickable:
 | A tab | Switches to it |
 | Outline / Backlinks / Tags | Switches panel |
 | A graph node | Selects it |
+| Text in the editor | Places the cursor; drag to select |
 | Scroll wheel | Scrolls the pane under the pointer, not the focused one |
 
 ## Features
@@ -173,6 +181,15 @@ The ribbon icons are buttons, and most of the UI is clickable:
 (dimmed when they don't resolve yet), `#tags`, `- [ ]` tasks, `> [!note]`
 callouts, tables, and fenced code with syntax highlighting. Frontmatter is
 optional: a Markdown file dropped in from anywhere shows up.
+
+**Editing.** Long lines wrap, so nothing is ever cut off at the edge of the pane,
+and the arrow keys follow the rows you can see. Markdown is styled as you type it
+— headings coloured, bullets drawn as `•`, tasks as `[☑]`, quotes as `▎` — but
+nothing is hidden and nothing moves: each glyph is exactly as wide as the
+character it stands for, so the cursor is always on the character it looks like
+it's on. The line you're editing shows its syntax at full contrast. Because both
+modes lay prose out in the same column at the same width, `Ctrl+E` restyles the
+page instead of reflowing it. Set `editor.wrap = false` to pan sideways instead.
 
 **Pictures.** `![[chart.png]]` and `![alt](assets/chart.png)` are drawn in the
 reading pane — real pixels in Kitty, Ghostty, WezTerm, iTerm2 and anything that
@@ -413,8 +430,8 @@ directory of `.sha256` files.
 
 ```sh
 # bump the version in Cargo.toml, update CHANGELOG.md, then:
-git tag -a v0.2.0 -m "v0.2.0"
-git push origin v0.2.0
+git tag -a v0.3.0 -m "v0.3.0"
+git push origin v0.3.0
 ```
 
 ## Credits

--- a/crates/otui-core/src/markdown.rs
+++ b/crates/otui-core/src/markdown.rs
@@ -726,6 +726,83 @@ pub fn spans_to_text(spans: &[Span]) -> String {
     spans.iter().map(|s| s.text.as_str()).collect()
 }
 
+/// What one character of a source line is, for colouring it where it sits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Ink {
+    #[default]
+    Text,
+    /// Syntax rather than content: a `**`, a `[[`, the `#` of a heading.
+    Marker,
+    WikiLink,
+    Link,
+    Tag,
+    Math,
+}
+
+impl Ink {
+    fn of(kind: &SpanKind) -> Self {
+        match kind {
+            SpanKind::Text => Self::Text,
+            SpanKind::WikiLink { .. } => Self::WikiLink,
+            SpanKind::Link { .. } => Self::Link,
+            // Alt text standing in for a picture reads as a link to it.
+            SpanKind::Image { .. } => Self::Link,
+            SpanKind::Tag(_) => Self::Tag,
+            SpanKind::Math => Self::Math,
+        }
+    }
+}
+
+/// One character of a source line, and what to make of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Paint {
+    pub style: Style,
+    pub ink: Ink,
+}
+
+/// Describes a source line character by character, without moving any of it.
+///
+/// The editor shows Markdown as it was typed, so it needs to know what each
+/// character *is* rather than what the reading pane would draw in its place.
+/// The styles come from [`parse_inline`] — one definition of the dialect, not
+/// two — and every character the parser dropped on the way is a delimiter, so
+/// it is reported as [`Ink::Marker`] for the editor to dim.
+///
+/// The result always has one entry per character of `line`.
+#[must_use]
+pub fn scan_inline(line: &str) -> Vec<Paint> {
+    let chars: Vec<char> = line.chars().collect();
+    // Syntax until the parser claims it as content.
+    let mut out = vec![
+        Paint {
+            style: Style::default(),
+            ink: Ink::Marker,
+        };
+        chars.len()
+    ];
+
+    let mut at = 0;
+    for span in parse_inline(line) {
+        let paint = Paint {
+            style: span.style,
+            ink: Ink::of(&span.kind),
+        };
+        // Span text is always a subsequence of the line: the parser either
+        // copies a character through or drops it.
+        for want in span.text.chars() {
+            while at < chars.len() && chars[at] != want {
+                at += 1;
+            }
+            if at == chars.len() {
+                return out;
+            }
+            out[at] = paint;
+            at += 1;
+        }
+    }
+    out
+}
+
 /// A short plain-text preview of a note body, as shown in list views.
 #[must_use]
 pub fn preview(body: &str, max_chars: usize) -> String {
@@ -999,6 +1076,67 @@ mod tests {
         let spans = parse_inline(r"\*not italic\*");
         assert_eq!(spans_to_text(&spans), "*not italic*");
         assert!(!spans.iter().any(|s| s.style.italic));
+    }
+
+    /// A one-character sketch of a scan: `.` content, `#` a delimiter.
+    fn shape(line: &str) -> String {
+        scan_inline(line)
+            .iter()
+            .map(|paint| if paint.ink == Ink::Marker { '#' } else { '.' })
+            .collect()
+    }
+
+    #[test]
+    fn scan_inline_marks_delimiters_where_they_sit() {
+        // The editor draws source, so it needs one entry per character, with the
+        // syntax told apart from the content rather than removed.
+        assert_eq!(shape("**bold** text"), "##....##.....");
+        assert_eq!(shape("a `code` b"), "..#....#..");
+        assert_eq!(shape("see [[Note]]"), "....##....##");
+        assert_eq!(shape("==mark=="), "##....##");
+    }
+
+    #[test]
+    fn scan_inline_always_describes_every_character() {
+        // Anything shorter would be indexed out of bounds while drawing.
+        for line in [
+            "",
+            "plain",
+            "a ** b",
+            "[[unclosed",
+            "` open",
+            r"\*escaped\*",
+            "héllo 日本語 **wide**",
+            "![](a.png)",
+            "[docs](https://e.com) #tag/deep",
+            "**nested `code` here**",
+        ] {
+            assert_eq!(
+                scan_inline(line).len(),
+                line.chars().count(),
+                "{line:?} was described by the wrong number of entries"
+            );
+        }
+    }
+
+    #[test]
+    fn scan_inline_carries_the_style_of_the_content_it_describes() {
+        let scan = scan_inline("**bold** and `code`");
+        assert!(scan[2].style.bold, "the b of bold");
+        assert!(!scan[0].style.bold, "not the delimiter");
+        assert!(scan[14].style.code, "the c of code");
+
+        let scan = scan_inline("a [[Target]] and a #tag");
+        assert_eq!(scan[4].ink, Ink::WikiLink);
+        assert_eq!(scan[20].ink, Ink::Tag);
+    }
+
+    #[test]
+    fn scan_inline_treats_an_unclosed_delimiter_as_content() {
+        // It renders as itself, so colouring it as syntax would be a lie about
+        // what the line is going to look like.
+        assert_eq!(shape("a ** b"), "......");
+        assert_eq!(shape("[[unclosed"), "..........");
     }
 
     #[test]

--- a/crates/otui/src/app.rs
+++ b/crates/otui/src/app.rs
@@ -319,6 +319,15 @@ pub struct Regions {
     pub side_tabs: Vec<(Rect, SidePanel)>,
     /// The sidebar's list area and the row index its first line shows.
     pub sidebar: Option<(Rect, usize)>,
+    /// The editor's text column — gutter and scrollbar excluded — and the row
+    /// its first line shows.
+    ///
+    /// Wrapping means the cursor's position depends on how wide the text was
+    /// drawn, so keys that move between rows read this too, not just the mouse.
+    pub editor: Option<(Rect, usize)>,
+    /// Which rendered row each block of the reading pane started on, as
+    /// `(source line, row)`, so the outline can scroll to a heading.
+    pub anchors: Vec<(usize, usize)>,
     pub main: Option<Rect>,
     pub chat: Option<Rect>,
     /// The graph canvas with its coordinate bounds, for hit-testing nodes.

--- a/crates/otui/src/editor.rs
+++ b/crates/otui/src/editor.rs
@@ -7,6 +7,26 @@
 //!
 //! Positions are in **characters**, not bytes, so a cursor never lands inside a
 //! multi-byte character.
+//!
+//! A long line is *shown* over several terminal rows, which is what [`Layout`]
+//! works out. That mapping is deliberately kept out of the buffer: the buffer
+//! stays the plain line-oriented model everything else parses and indexes, and
+//! only the parts that draw or move the cursor need to know how it was wrapped.
+
+use unicode_width::UnicodeWidthChar;
+
+/// Display columns a character occupies.
+///
+/// A tab is one character but is drawn as spaces to the next stop, so measuring
+/// it as one column would put the caret in the wrong place on any indented line.
+#[must_use]
+fn char_width(ch: char, tab_width: usize, column: usize) -> usize {
+    if ch == '\t' {
+        tab_width - (column % tab_width.max(1))
+    } else {
+        ch.width().unwrap_or(0)
+    }
+}
 
 /// A position in the buffer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
@@ -14,6 +34,247 @@ pub struct Cursor {
     pub line: usize,
     /// Character offset within the line.
     pub col: usize,
+}
+
+/// One terminal row: the slice of a source line that is drawn on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Row {
+    /// Index of the source line this row came from.
+    pub line: usize,
+    /// First character of that line shown here.
+    pub start: usize,
+    /// One past the last character shown here.
+    pub end: usize,
+    /// Blank columns before the text, so a wrapped list item lines up under
+    /// its own words rather than under its bullet.
+    pub indent: u16,
+    /// False on a soft-wrap continuation of the row above.
+    pub first: bool,
+}
+
+/// How the buffer's lines were laid out across the rows of a viewport.
+///
+/// Rebuilt wherever it is needed rather than cached: it costs one pass over the
+/// text, which is what the reading pane already spends parsing Markdown every
+/// frame, and a cache here would only be a way to draw a stale note.
+#[derive(Debug, Clone)]
+pub struct Layout {
+    rows: Vec<Row>,
+    /// Index into `rows` of the first row of each source line.
+    first: Vec<usize>,
+    /// Columns the text was wrapped to.
+    width: usize,
+    wrapped: bool,
+}
+
+/// Narrowest column a wrapped line is ever squeezed into.
+///
+/// A deeply indented list item in a slim pane would otherwise be wrapped to
+/// nothing and loop forever; below this the hanging indent is given up instead.
+const MIN_WRAP: usize = 12;
+
+impl Layout {
+    /// Lays `lines` out for a viewport `width` columns wide.
+    ///
+    /// With `wrap` off every line gets exactly one row, however long it is, and
+    /// the viewport pans sideways instead — which is what someone who turned
+    /// wrapping off asked for.
+    #[must_use]
+    pub fn build(lines: &[String], width: usize, wrap: bool, tab_width: usize) -> Self {
+        let mut rows = Vec::with_capacity(lines.len());
+        let mut first = Vec::with_capacity(lines.len());
+
+        for (index, text) in lines.iter().enumerate() {
+            first.push(rows.len());
+            let chars: Vec<char> = text.chars().collect();
+            if !wrap || width == 0 {
+                rows.push(Row {
+                    line: index,
+                    start: 0,
+                    end: chars.len(),
+                    indent: 0,
+                    first: true,
+                });
+                continue;
+            }
+            wrap_line(&chars, index, width, tab_width, &mut rows);
+        }
+
+        // An empty buffer still has one line, so there is always a row to put
+        // the cursor on.
+        if rows.is_empty() {
+            first.push(0);
+            rows.push(Row {
+                line: 0,
+                start: 0,
+                end: 0,
+                indent: 0,
+                first: true,
+            });
+        }
+
+        Self {
+            rows,
+            first,
+            width,
+            wrapped: wrap,
+        }
+    }
+
+    #[must_use]
+    pub fn rows(&self) -> &[Row] {
+        &self.rows
+    }
+
+    #[must_use]
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    #[must_use]
+    pub fn wrapped(&self) -> bool {
+        self.wrapped
+    }
+
+    /// The row a cursor sits on.
+    ///
+    /// At a wrap boundary the cursor belongs to the start of the following row,
+    /// not the end of the one before, so typing carries on where the text does.
+    #[must_use]
+    pub fn row_of(&self, cursor: Cursor) -> usize {
+        let last = self.rows.len() - 1;
+        let Some(&start) = self.first.get(cursor.line) else {
+            return last;
+        };
+        let mut index = start.min(last);
+        while index < last
+            && self.rows[index + 1].line == cursor.line
+            && self.rows[index + 1].start <= cursor.col
+        {
+            index += 1;
+        }
+        index
+    }
+
+    /// The row and display column a cursor is drawn at.
+    #[must_use]
+    pub fn position_of(&self, cursor: Cursor, lines: &[String], tab_width: usize) -> (usize, u16) {
+        let index = self.row_of(cursor);
+        let row = self.rows[index];
+        let mut column = usize::from(row.indent);
+        if let Some(text) = lines.get(row.line) {
+            for ch in text.chars().take(cursor.col).skip(row.start) {
+                column += char_width(ch, tab_width, column);
+            }
+        }
+        (index, u16::try_from(column).unwrap_or(u16::MAX))
+    }
+
+    /// The cursor at a row and display column — how a click and a vertical move
+    /// both land somewhere sensible.
+    #[must_use]
+    pub fn cursor_at(&self, row: usize, column: u16, lines: &[String], tab_width: usize) -> Cursor {
+        let row = self.rows[row.min(self.rows.len() - 1)];
+        let target = usize::from(column).saturating_sub(usize::from(row.indent));
+        let mut col = row.start;
+        let mut at = usize::from(row.indent);
+
+        if let Some(text) = lines.get(row.line) {
+            for ch in text.chars().take(row.end).skip(row.start) {
+                let width = char_width(ch, tab_width, at);
+                // Land on whichever character the column falls closest to, so
+                // clicking the right half of a wide glyph lands after it.
+                if at + width > usize::from(row.indent) + target {
+                    break;
+                }
+                at += width;
+                col += 1;
+            }
+        }
+        Cursor {
+            line: row.line,
+            col,
+        }
+    }
+}
+
+/// Breaks one line into rows at word boundaries.
+fn wrap_line(chars: &[char], line: usize, width: usize, tab_width: usize, out: &mut Vec<Row>) {
+    if chars.is_empty() {
+        out.push(Row {
+            line,
+            start: 0,
+            end: 0,
+            indent: 0,
+            first: true,
+        });
+        return;
+    }
+
+    let hanging = hanging_indent(chars, tab_width, width);
+    let mut start = 0;
+    let mut first = true;
+
+    while start < chars.len() {
+        let indent = if first { 0 } else { hanging };
+        let available = width.saturating_sub(usize::from(indent)).max(1);
+
+        let mut column = 0;
+        let mut at = start;
+        // One past the last space that fits, which is where the line would
+        // rather break.
+        let mut boundary = None;
+        while at < chars.len() {
+            let next = column + char_width(chars[at], tab_width, column);
+            if next > available && at > start {
+                break;
+            }
+            column = next;
+            at += 1;
+            if chars[at - 1] == ' ' {
+                boundary = Some(at);
+            }
+        }
+
+        // Breaking after the space keeps it on this row, where it is invisible,
+        // instead of indenting the next one by a stray blank.
+        let end = match boundary {
+            Some(boundary) if at < chars.len() && boundary > start => boundary,
+            _ => at,
+        };
+
+        out.push(Row {
+            line,
+            start,
+            end,
+            indent,
+            first,
+        });
+        start = end;
+        first = false;
+    }
+}
+
+/// Columns a wrapped line's continuations are indented by.
+///
+/// A wrapped bullet reads as one item when its second row starts under the
+/// first row's text, and as two items when it starts under the bullet.
+fn hanging_indent(chars: &[char], tab_width: usize, width: usize) -> u16 {
+    let mut column = 0;
+    let mut at = 0;
+    while at < chars.len() && (chars[at] == ' ' || chars[at] == '\t') {
+        column += char_width(chars[at], tab_width, column);
+        at += 1;
+    }
+    // The marker itself. Every marker is ASCII, so its length in bytes, in
+    // characters and in columns are all the same number.
+    let rest: String = chars[at..].iter().collect();
+    column += marker_len(&rest).unwrap_or(0);
+
+    if width.saturating_sub(column) < MIN_WRAP {
+        return 0;
+    }
+    u16::try_from(column).unwrap_or(0)
 }
 
 /// What kind of edit was last applied, used to group undo steps.
@@ -33,11 +294,19 @@ struct Snapshot {
 pub struct Editor {
     lines: Vec<String>,
     cursor: Cursor,
-    /// Column the cursor wants when moving vertically, so travelling through a
-    /// short line and back out preserves the original column.
-    desired_col: usize,
+    /// Display column the cursor wants when moving between rows, so travelling
+    /// through a short row and back out preserves the original column.
+    ///
+    /// Cleared by every other kind of movement, and by editing, so it only ever
+    /// holds a column the user actually aimed at.
+    desired_col: Option<u16>,
     selection_anchor: Option<Cursor>,
+    /// Rows scrolled off the top — terminal rows, not source lines, since one
+    /// long line can occupy several of them.
     pub scroll: usize,
+    /// Columns scrolled off the left. Only ever non-zero with wrapping off,
+    /// where reaching the end of a long line is the whole point.
+    pub hscroll: usize,
     modified: bool,
     undo: Vec<Snapshot>,
     redo: Vec<Snapshot>,
@@ -56,9 +325,10 @@ impl Editor {
         Self {
             lines: split_lines(text),
             cursor: Cursor::default(),
-            desired_col: 0,
+            desired_col: None,
             selection_anchor: None,
             scroll: 0,
+            hscroll: 0,
             modified: false,
             undo: Vec::new(),
             redo: Vec::new(),
@@ -71,6 +341,18 @@ impl Editor {
     #[must_use]
     pub fn lines(&self) -> &[String] {
         &self.lines
+    }
+
+    /// How this buffer falls across the rows of a viewport `width` columns wide.
+    #[must_use]
+    pub fn layout(&self, width: usize, wrap: bool) -> Layout {
+        Layout::build(&self.lines, width, wrap, self.tab_width)
+    }
+
+    /// The row and display column the caret should be drawn at.
+    #[must_use]
+    pub fn caret(&self, layout: &Layout) -> (usize, u16) {
+        layout.position_of(self.cursor, &self.lines, self.tab_width)
     }
 
     #[must_use]
@@ -143,7 +425,6 @@ impl Editor {
             self.cursor.line -= 1;
             self.cursor.col = self.line_len(self.cursor.line);
         }
-        self.desired_col = self.cursor.col;
     }
 
     pub fn move_right(&mut self, extend: bool) {
@@ -154,45 +435,71 @@ impl Editor {
             self.cursor.line += 1;
             self.cursor.col = 0;
         }
-        self.desired_col = self.cursor.col;
     }
 
-    pub fn move_up(&mut self, extend: bool) {
+    /// Moves `delta` terminal rows, following the text as it was wrapped.
+    ///
+    /// Moving by wrapped row rather than by source line is what makes the arrow
+    /// keys agree with the screen: on a paragraph that fills four rows, four
+    /// presses of `Down` cross it, as they would anywhere else.
+    pub fn move_row(&mut self, layout: &Layout, delta: isize, extend: bool) {
+        // Read the aimed-for column before `prepare_move` forgets it.
+        let (row, column) = layout.position_of(self.cursor, &self.lines, self.tab_width);
+        let want = self.desired_col.unwrap_or(column);
         self.prepare_move(extend);
-        if self.cursor.line > 0 {
-            self.cursor.line -= 1;
-            self.cursor.col = self.desired_col.min(self.line_len(self.cursor.line));
-        } else {
-            self.cursor.col = 0;
-        }
+
+        let last = layout.rows().len().saturating_sub(1) as isize;
+        let target = (row as isize + delta).clamp(0, last) as usize;
+        self.cursor = layout.cursor_at(target, want, &self.lines, self.tab_width);
+        self.desired_col = Some(want);
     }
 
-    pub fn move_down(&mut self, extend: bool) {
-        self.prepare_move(extend);
-        if self.cursor.line + 1 < self.lines.len() {
-            self.cursor.line += 1;
-            self.cursor.col = self.desired_col.min(self.line_len(self.cursor.line));
-        } else {
-            self.cursor.col = self.line_len(self.cursor.line);
+    /// `Home`: the start of the row on screen.
+    ///
+    /// On the first row of a line this keeps the behavior every editor settled
+    /// on for indented text — the first non-blank, then column zero — because
+    /// that is where the interesting positions are. On a wrapped continuation
+    /// there is only one sensible answer: where the row begins.
+    pub fn move_row_start(&mut self, layout: &Layout, extend: bool) {
+        let row = layout.rows()[layout.row_of(self.cursor)];
+        if !row.first {
+            self.prepare_move(extend);
+            self.cursor.col = row.start;
+            return;
         }
+        self.move_line_start(extend);
+    }
+
+    /// `End`: the end of the row on screen, which on the last row of a line is
+    /// the end of the line.
+    pub fn move_row_end(&mut self, layout: &Layout, extend: bool) {
+        let row = layout.rows()[layout.row_of(self.cursor)];
+        if row.end == self.line_len(row.line) {
+            self.move_line_end(extend);
+            return;
+        }
+        self.prepare_move(extend);
+        self.cursor.col = row.end;
+    }
+
+    /// Places the cursor at a row and display column, for a click or a drag.
+    pub fn goto_visual(&mut self, layout: &Layout, row: usize, column: u16, extend: bool) {
+        self.prepare_move(extend);
+        self.cursor = layout.cursor_at(row, column, &self.lines, self.tab_width);
     }
 
     pub fn move_line_start(&mut self, extend: bool) {
         self.prepare_move(extend);
-        // Home goes to the first non-blank first, then to column zero — the
-        // behavior every editor settled on for indented text.
         let indent = self.lines[self.cursor.line]
             .chars()
             .take_while(|c| c.is_whitespace())
             .count();
         self.cursor.col = if self.cursor.col == indent { 0 } else { indent };
-        self.desired_col = self.cursor.col;
     }
 
     pub fn move_line_end(&mut self, extend: bool) {
         self.prepare_move(extend);
         self.cursor.col = self.line_len(self.cursor.line);
-        self.desired_col = self.cursor.col;
     }
 
     pub fn move_word_left(&mut self, extend: bool) {
@@ -213,7 +520,6 @@ impl Editor {
             }
             self.cursor.col = col;
         }
-        self.desired_col = self.cursor.col;
     }
 
     pub fn move_word_right(&mut self, extend: bool) {
@@ -234,37 +540,30 @@ impl Editor {
             }
             self.cursor.col = col;
         }
-        self.desired_col = self.cursor.col;
-    }
-
-    pub fn move_page(&mut self, lines: isize, extend: bool) {
-        self.prepare_move(extend);
-        let target = (self.cursor.line as isize + lines).clamp(0, self.lines.len() as isize - 1);
-        self.cursor.line = target as usize;
-        self.cursor.col = self.desired_col.min(self.line_len(self.cursor.line));
     }
 
     pub fn move_document_start(&mut self, extend: bool) {
         self.prepare_move(extend);
         self.cursor = Cursor::default();
-        self.desired_col = 0;
     }
 
     pub fn move_document_end(&mut self, extend: bool) {
         self.prepare_move(extend);
         self.cursor = self.end_position();
-        self.desired_col = self.cursor.col;
     }
 
     /// Places the cursor at a specific position, clamped into the buffer.
     pub fn goto(&mut self, line: usize, col: usize) {
         self.cursor.line = line.min(self.lines.len().saturating_sub(1));
         self.cursor.col = col.min(self.line_len(self.cursor.line));
-        self.desired_col = self.cursor.col;
+        self.desired_col = None;
         self.selection_anchor = None;
     }
 
     fn prepare_move(&mut self, extend: bool) {
+        // Any move that isn't between rows abandons the column the cursor was
+        // aiming for; only `move_row` puts one back.
+        self.desired_col = None;
         if extend {
             if self.selection_anchor.is_none() {
                 self.selection_anchor = Some(self.cursor);
@@ -302,20 +601,103 @@ impl Editor {
         }
     }
 
+    /// `Enter`. Carries indentation, and continues a list.
+    ///
+    /// Continuing the list is what makes a terminal usable for notes at all:
+    /// typing a checklist otherwise means retyping `- [ ] ` on every line.
+    /// Pressing it on an item with nothing in it ends the list instead, which is
+    /// how you stop — the same rule Obsidian uses.
     pub fn newline(&mut self) {
         self.push_undo(EditKind::Structural);
         self.delete_selection_inner();
 
-        // Carry the current line's indentation, which is what makes editing
-        // nested lists bearable.
-        let indent: String = self.lines[self.cursor.line]
+        let line = self.lines[self.cursor.line].clone();
+        let indent: String = line
             .chars()
             .take_while(|c| *c == ' ' || *c == '\t')
             .collect();
-        self.split_line();
-        if !indent.is_empty() {
-            self.insert_into_line(&indent);
+        let marker = marker(&line[indent.len()..]);
+
+        // An item with only a marker on it: clear the line rather than adding
+        // another empty one below.
+        if let Some(marker) = &marker
+            && line[indent.len() + marker.len..].trim().is_empty()
+        {
+            self.lines[self.cursor.line] = String::new();
+            self.cursor.col = 0;
+            self.desired_col = None;
+            self.modified = true;
+            return;
         }
+
+        self.split_line();
+        let carry = match &marker {
+            Some(marker) => format!("{indent}{}", marker.next),
+            None => indent,
+        };
+        if !carry.is_empty() {
+            self.insert_into_line(&carry);
+        }
+    }
+
+    /// `Tab` and `Shift+Tab`.
+    ///
+    /// Inside a list item, or with several lines selected, `Tab` nests rather
+    /// than inserting a tab character — in a list that is the only thing it
+    /// could reasonably mean. Anywhere else it is still a tab.
+    pub fn tab(&mut self, forward: bool) {
+        if !forward {
+            self.indent(false);
+            return;
+        }
+        let line = &self.lines[self.cursor.line];
+        let in_list = marker(line.trim_start()).is_some();
+        if in_list || self.selection().is_some() {
+            self.indent(true);
+        } else {
+            self.insert_char('\t');
+        }
+    }
+
+    /// Indents or outdents every line the cursor or the selection touches.
+    pub fn indent(&mut self, forward: bool) {
+        self.push_undo(EditKind::Structural);
+        let (start, end) = self
+            .selection()
+            .map_or((self.cursor, self.cursor), |(s, e)| (s, e));
+
+        let step = if self.expand_tabs {
+            " ".repeat(self.tab_width)
+        } else {
+            "\t".to_string()
+        };
+        let mut moved = 0;
+        for line in start.line..=end.line.min(self.lines.len() - 1) {
+            if forward {
+                self.lines[line].insert_str(0, &step);
+                moved = step.chars().count();
+                continue;
+            }
+            // Outdenting takes back a whole stop, or whatever less is there.
+            let removable = self.lines[line]
+                .chars()
+                .take(step.chars().count())
+                .take_while(|c| *c == ' ' || *c == '\t')
+                .count();
+            self.lines[line] = self.lines[line].chars().skip(removable).collect();
+            if line == self.cursor.line {
+                moved = removable;
+            }
+        }
+
+        self.cursor.col = if forward {
+            self.cursor.col + moved
+        } else {
+            self.cursor.col.saturating_sub(moved)
+        };
+        self.desired_col = None;
+        self.selection_anchor = None;
+        self.modified = true;
     }
 
     pub fn backspace(&mut self) {
@@ -352,7 +734,7 @@ impl Editor {
             self.cursor.col = self.line_len(self.cursor.line);
             self.lines[self.cursor.line].push_str(&current);
         }
-        self.desired_col = self.cursor.col;
+        self.desired_col = None;
         self.modified = true;
     }
 
@@ -456,7 +838,7 @@ impl Editor {
         self.lines.insert(start.line, format!("{head}{tail}"));
 
         self.cursor = start;
-        self.desired_col = start.col;
+        self.desired_col = None;
         self.selection_anchor = None;
         self.modified = true;
     }
@@ -469,7 +851,7 @@ impl Editor {
         line.extend(chars[col..].iter());
         self.lines[self.cursor.line] = line;
         self.cursor.col = col + text.chars().count();
-        self.desired_col = self.cursor.col;
+        self.desired_col = None;
         self.modified = true;
     }
 
@@ -482,7 +864,7 @@ impl Editor {
         self.lines.insert(self.cursor.line + 1, tail);
         self.cursor.line += 1;
         self.cursor.col = 0;
-        self.desired_col = 0;
+        self.desired_col = None;
         self.modified = true;
     }
 
@@ -578,17 +960,107 @@ impl Editor {
         out
     }
 
-    /// Scrolls so the cursor is visible in a viewport of `height` lines.
-    pub fn scroll_into_view(&mut self, height: usize) {
+    /// Scrolls so the cursor is visible in a viewport `height` rows tall.
+    ///
+    /// Rows, not lines: with wrapping on, a paragraph the cursor is halfway
+    /// through may be taller than the viewport on its own.
+    pub fn scroll_into_view(&mut self, layout: &Layout, height: usize) {
         if height == 0 {
             return;
         }
-        if self.cursor.line < self.scroll {
-            self.scroll = self.cursor.line;
-        } else if self.cursor.line >= self.scroll + height {
-            self.scroll = self.cursor.line + 1 - height;
+        let (row, column) = self.caret(layout);
+        if row < self.scroll {
+            self.scroll = row;
+        } else if row >= self.scroll + height {
+            self.scroll = row + 1 - height;
+        }
+        // Never leave blank rows below a note that would fit further up.
+        self.scroll = self.scroll.min(layout.rows().len().saturating_sub(height));
+
+        // Panning sideways only happens with wrapping off; a wrapped row always
+        // fits the viewport it was wrapped to.
+        if layout.wrapped() || layout.width() == 0 {
+            self.hscroll = 0;
+            return;
+        }
+        let column = usize::from(column);
+        if column < self.hscroll {
+            self.hscroll = column;
+        } else if column >= self.hscroll + layout.width() {
+            self.hscroll = column + 1 - layout.width();
         }
     }
+}
+
+/// A list marker at the start of a line, and what continues it below.
+struct Continuation {
+    /// Bytes of the marker, including its trailing space.
+    len: usize,
+    /// What the next line should start with after the same indentation.
+    next: String,
+}
+
+/// Reads the list marker at the start of `rest`, which must already have its
+/// indentation stripped.
+///
+/// One place knows what a marker looks like, and three things ask it: how far
+/// to indent a wrapped row, what `Enter` should carry down, and whether `Tab`
+/// means "nest this item" or "insert a tab".
+fn marker(rest: &str) -> Option<Continuation> {
+    let bytes = rest.as_bytes();
+    let bullet = matches!(bytes.first(), Some(b'-' | b'*' | b'+')) && bytes.get(1) == Some(&b' ');
+
+    // A task box, checked or not, always continues as an empty one: carrying
+    // "done" down to a line nobody has done yet would be a lie.
+    if bullet
+        && bytes.get(2) == Some(&b'[')
+        && matches!(bytes.get(3), Some(b' ' | b'x' | b'X'))
+        && bytes.get(4) == Some(&b']')
+        && bytes.get(5) == Some(&b' ')
+    {
+        return Some(Continuation {
+            len: 6,
+            next: format!("{} [ ] ", &rest[..1]),
+        });
+    }
+    if bullet {
+        return Some(Continuation {
+            len: 2,
+            next: rest[..2].to_string(),
+        });
+    }
+
+    // `1. ` or `1) `, continuing with the next number.
+    let digits = rest.chars().take_while(char::is_ascii_digit).count();
+    if digits > 0
+        && matches!(bytes.get(digits), Some(b'.' | b')'))
+        && bytes.get(digits + 1) == Some(&b' ')
+    {
+        let number: u64 = rest[..digits].parse().unwrap_or(0);
+        return Some(Continuation {
+            len: digits + 2,
+            next: format!("{}{} ", number + 1, &rest[digits..=digits]),
+        });
+    }
+
+    // Every level of a `> > ` quote, repeated verbatim.
+    let quote = rest
+        .bytes()
+        .take_while(|byte| matches!(byte, b'>' | b' '))
+        .count();
+    if quote > 0 && rest.starts_with('>') {
+        return Some(Continuation {
+            len: quote,
+            next: rest[..quote].to_string(),
+        });
+    }
+
+    None
+}
+
+/// Bytes of the list marker at the start of `rest`, if any.
+fn marker_len(rest: &str) -> Option<usize> {
+    marker(rest).map(|marker| marker.len)
 }
 
 fn split_lines(text: &str) -> Vec<String> {
@@ -688,14 +1160,38 @@ mod tests {
         assert_eq!(ed.text(), "abcd\n");
     }
 
+    /// A layout wide enough that nothing wraps, so a row is a line.
+    fn unwrapped(ed: &Editor) -> Layout {
+        ed.layout(200, true)
+    }
+
     #[test]
     fn vertical_movement_remembers_the_desired_column() {
         let mut ed = editor("longer line\nx\nanother long line");
+        let layout = unwrapped(&ed);
         ed.goto(0, 9);
-        ed.move_down(false);
+        ed.move_row(&layout, 1, false);
         assert_eq!(ed.cursor().col, 1, "clamped to the short line");
-        ed.move_down(false);
+        ed.move_row(&layout, 1, false);
         assert_eq!(ed.cursor().col, 9, "restored on the longer line");
+    }
+
+    #[test]
+    fn typing_forgets_the_column_a_vertical_move_was_aiming_for() {
+        // Otherwise the cursor jumps back to a column the user left behind.
+        let mut ed = editor("longer line\nx\nanother long line");
+        let layout = unwrapped(&ed);
+        ed.goto(0, 9);
+        ed.move_row(&layout, 1, false);
+        ed.insert_char('!');
+
+        let layout = unwrapped(&ed);
+        ed.move_row(&layout, 1, false);
+        assert_eq!(
+            ed.cursor().col,
+            2,
+            "the column comes from where typing left it"
+        );
     }
 
     #[test]
@@ -856,14 +1352,222 @@ mod tests {
     fn scroll_follows_the_cursor_both_ways() {
         let text: String = (0..100).map(|i| format!("line {i}\n")).collect();
         let mut ed = editor(&text);
+        let layout = unwrapped(&ed);
 
         ed.goto(50, 0);
-        ed.scroll_into_view(10);
+        ed.scroll_into_view(&layout, 10);
         assert_eq!(ed.scroll, 41, "cursor sits on the last visible row");
 
         ed.goto(5, 0);
-        ed.scroll_into_view(10);
+        ed.scroll_into_view(&layout, 10);
         assert_eq!(ed.scroll, 5);
+    }
+
+    #[test]
+    fn scroll_counts_wrapped_rows_not_lines() {
+        // Three lines that each take four rows: the cursor on the last one is 12
+        // rows down, not 3, and scrolling by lines would leave it off screen.
+        let mut ed = editor("aaa bbb ccc ddd\neee fff ggg hhh\niii jjj kkk lll");
+        let layout = ed.layout(4, true);
+        assert_eq!(layout.rows().len(), 12);
+
+        ed.goto(2, 15);
+        ed.scroll_into_view(&layout, 5);
+        let (row, _) = ed.caret(&layout);
+        assert!(
+            row >= ed.scroll && row < ed.scroll + 5,
+            "row {row} is off a viewport starting at {}",
+            ed.scroll
+        );
+    }
+
+    #[test]
+    fn a_short_note_never_scrolls_past_its_own_end() {
+        let mut ed = editor("one\ntwo\nthree");
+        let layout = unwrapped(&ed);
+        ed.scroll = 99;
+        ed.goto(0, 0);
+        ed.scroll_into_view(&layout, 10);
+        assert_eq!(ed.scroll, 0, "no blank rows above a note that fits");
+    }
+
+    #[test]
+    fn wrapping_off_pans_sideways_to_reach_the_end_of_a_long_line() {
+        let mut ed = editor(&"x".repeat(200));
+        let layout = ed.layout(40, false);
+        assert_eq!(layout.rows().len(), 1, "one row, however long the line");
+
+        ed.move_line_end(false);
+        ed.scroll_into_view(&layout, 10);
+        assert_eq!(ed.hscroll, 161, "the caret is at the right edge");
+    }
+
+    #[test]
+    fn a_long_line_wraps_at_word_boundaries() {
+        let ed = editor("the quick brown fox jumps");
+        let layout = ed.layout(10, true);
+        let rows: Vec<&str> = layout
+            .rows()
+            .iter()
+            .map(|row| &ed.lines()[row.line][row.start..row.end])
+            .collect();
+
+        assert_eq!(rows, vec!["the quick ", "brown fox ", "jumps"]);
+        for row in layout.rows() {
+            assert!(row.end - row.start <= 10, "no row is wider than the pane");
+        }
+    }
+
+    #[test]
+    fn a_word_longer_than_the_pane_is_broken_rather_than_lost() {
+        let ed = editor("supercalifragilistic");
+        let layout = ed.layout(8, true);
+        assert!(layout.rows().len() > 1);
+        assert_eq!(
+            layout
+                .rows()
+                .iter()
+                .map(|row| row.end - row.start)
+                .sum::<usize>(),
+            20,
+            "every character is on some row"
+        );
+    }
+
+    #[test]
+    fn a_wrapped_list_item_lines_up_under_its_own_text() {
+        let ed = editor("- alpha beta gamma delta epsilon");
+        let layout = ed.layout(20, true);
+        let rows = layout.rows();
+
+        assert!(rows.len() > 1, "should wrap");
+        assert_eq!(rows[0].indent, 0);
+        assert_eq!(rows[1].indent, 2, "indented past the bullet, not under it");
+    }
+
+    #[test]
+    fn the_caret_and_a_click_agree_on_where_a_character_is() {
+        // Wide characters occupy two columns, so a column is not a character.
+        let mut ed = editor("héllo 日本語 world text here");
+        let layout = ed.layout(12, true);
+
+        for col in 0..ed.lines()[0].chars().count() {
+            ed.goto(0, col);
+            let (row, column) = ed.caret(&layout);
+            let back = layout.cursor_at(row, column, ed.lines(), 4);
+            assert_eq!(
+                back,
+                Cursor { line: 0, col },
+                "column {column} on row {row} should map back to character {col}"
+            );
+        }
+    }
+
+    #[test]
+    fn moving_down_a_wrapped_paragraph_walks_it_row_by_row() {
+        let mut ed = editor("aaa bbb ccc ddd eee fff");
+        let layout = ed.layout(8, true);
+        ed.goto(0, 0);
+
+        let mut rows = vec![ed.caret(&layout).0];
+        for _ in 0..2 {
+            ed.move_row(&layout, 1, false);
+            rows.push(ed.caret(&layout).0);
+        }
+        assert_eq!(rows, vec![0, 1, 2], "one press, one row");
+    }
+
+    #[test]
+    fn home_and_end_work_on_the_row_not_the_line() {
+        let mut ed = editor("aaa bbb ccc ddd");
+        let layout = ed.layout(8, true);
+        // Second row: "ccc ddd".
+        ed.goto(0, 10);
+
+        ed.move_row_end(&layout, false);
+        assert_eq!(ed.cursor().col, 15);
+        ed.move_row_start(&layout, false);
+        assert_eq!(ed.cursor().col, 8, "the start of what is on screen");
+    }
+
+    #[test]
+    fn enter_continues_a_list_and_an_empty_item_ends_it() {
+        let mut ed = editor("- first");
+        ed.move_line_end(false);
+        ed.newline();
+        assert_eq!(ed.text(), "- first\n- \n");
+
+        ed.insert_char('x');
+        ed.newline();
+        assert_eq!(ed.text(), "- first\n- x\n- \n");
+
+        // Nothing typed on the new item: Enter ends the list.
+        ed.newline();
+        assert_eq!(ed.text(), "- first\n- x\n\n");
+    }
+
+    #[test]
+    fn enter_numbers_the_next_item_and_leaves_a_task_unchecked() {
+        let mut ed = editor("3. third");
+        ed.move_line_end(false);
+        ed.newline();
+        assert_eq!(ed.text(), "3. third\n4. \n");
+
+        let mut ed = editor("  - [x] done");
+        ed.move_line_end(false);
+        ed.newline();
+        assert_eq!(
+            ed.text(),
+            "  - [x] done\n  - [ ] \n",
+            "indentation carries and the box starts empty"
+        );
+    }
+
+    #[test]
+    fn enter_carries_a_quote_and_splits_text_mid_item() {
+        let mut ed = editor("> quoted");
+        ed.move_line_end(false);
+        ed.newline();
+        assert_eq!(ed.text(), "> quoted\n> \n");
+
+        let mut ed = editor("- alphabeta");
+        ed.goto(0, 7);
+        ed.newline();
+        assert_eq!(ed.text(), "- alpha\n- beta\n");
+    }
+
+    #[test]
+    fn tab_nests_a_list_item_but_is_still_a_tab_in_prose() {
+        let mut ed = editor("- item");
+        ed.move_line_end(false);
+        ed.tab(true);
+        assert_eq!(ed.text(), "    - item\n");
+        ed.tab(false);
+        assert_eq!(ed.text(), "- item\n");
+
+        let mut ed = editor("prose");
+        ed.move_line_end(false);
+        ed.tab(true);
+        assert_eq!(ed.text(), "prose   \n", "a tab to the next stop");
+    }
+
+    #[test]
+    fn tab_indents_every_line_of_a_selection() {
+        let mut ed = editor("one\ntwo\nthree");
+        ed.goto(0, 0);
+        ed.begin_selection();
+        ed.goto_extend(1, 1);
+        ed.tab(true);
+        assert_eq!(ed.text(), "    one\n    two\nthree\n");
+    }
+
+    #[test]
+    fn outdenting_takes_back_only_what_is_there() {
+        let mut ed = editor("  two spaces");
+        ed.tab(false);
+        assert_eq!(ed.text(), "two spaces\n");
+        ed.tab(false);
+        assert_eq!(ed.text(), "two spaces\n", "and stops at the margin");
     }
 
     #[test]

--- a/crates/otui/src/keys.rs
+++ b/crates/otui/src/keys.rs
@@ -404,6 +404,18 @@ fn handle_editing(app: &mut App, key: KeyEvent) {
         }
     }
 
+    // Moving between rows has to follow the text as it was wrapped, so it needs
+    // the geometry the last frame recorded — the same source of truth clicks
+    // are resolved against.
+    if matches!(
+        key.code,
+        KeyCode::Up | KeyCode::Down | KeyCode::PageUp | KeyCode::PageDown
+    ) || (!ctrl && matches!(key.code, KeyCode::Home | KeyCode::End))
+    {
+        move_in_editor(app, key.code, shift);
+        return;
+    }
+
     let Some(editor) = app.editor_mut() else {
         return;
     };
@@ -411,25 +423,42 @@ fn handle_editing(app: &mut App, key: KeyEvent) {
     match key.code {
         KeyCode::Char(ch) if !ctrl => editor.insert_char(ch),
         KeyCode::Enter => editor.newline(),
-        KeyCode::Tab => editor.insert_char('\t'),
+        KeyCode::Tab => editor.tab(true),
+        KeyCode::BackTab => editor.tab(false),
         KeyCode::Backspace => editor.backspace(),
         KeyCode::Delete => editor.delete_forward(),
         KeyCode::Left if ctrl => editor.move_word_left(shift),
         KeyCode::Right if ctrl => editor.move_word_right(shift),
         KeyCode::Left => editor.move_left(shift),
         KeyCode::Right => editor.move_right(shift),
-        KeyCode::Up => editor.move_up(shift),
-        KeyCode::Down => editor.move_down(shift),
         KeyCode::Home if ctrl => editor.move_document_start(shift),
         KeyCode::End if ctrl => editor.move_document_end(shift),
-        KeyCode::Home => editor.move_line_start(shift),
-        KeyCode::End => editor.move_line_end(shift),
-        KeyCode::PageUp => editor.move_page(-15, shift),
-        KeyCode::PageDown => editor.move_page(15, shift),
         KeyCode::Esc => {
             editor.commit();
             dispatch(app, Action::ToggleMode);
         }
+        _ => {}
+    }
+}
+
+/// Moves the cursor by what is on screen rather than by source line.
+fn move_in_editor(app: &mut App, code: KeyCode, extend: bool) {
+    let (width, height) = crate::ui::note::edit_viewport(app);
+    let wrap = app.config.editor.wrap;
+    let Some(editor) = app.editor_mut() else {
+        return;
+    };
+
+    let layout = editor.layout(width, wrap);
+    // A page is the viewport, less a row of overlap so the eye keeps its place.
+    let page = height.saturating_sub(1).max(1) as isize;
+    match code {
+        KeyCode::Up => editor.move_row(&layout, -1, extend),
+        KeyCode::Down => editor.move_row(&layout, 1, extend),
+        KeyCode::PageUp => editor.move_row(&layout, -page, extend),
+        KeyCode::PageDown => editor.move_row(&layout, page, extend),
+        KeyCode::Home => editor.move_row_start(&layout, extend),
+        KeyCode::End => editor.move_row_end(&layout, extend),
         _ => {}
     }
 }
@@ -453,8 +482,14 @@ fn handle_sidebar(app: &mut App, key: KeyEvent) {
             Some(SidebarTarget::Heading(line)) => {
                 // Jumping to a heading scrolls the reading view and moves the
                 // editor's cursor, whichever mode is active.
+                //
+                // The outline names a line in the file, but the reading view
+                // scrolls by rendered rows — prose wraps, headings gain a rule,
+                // a picture takes a dozen rows — so the two have to be
+                // translated through what the last frame actually drew.
+                let row = crate::ui::note::anchor_row(&app.regions.anchors, line);
                 if let Some(tab) = app.active_mut() {
-                    tab.scroll = line;
+                    tab.scroll = row;
                 }
                 if let Some(editor) = app.editor_mut() {
                     editor.goto(line, 0);
@@ -975,6 +1010,55 @@ mod tests {
 
         assert_eq!(app.explorer.filter, "B");
         assert_eq!(app.explorer.len(), 1);
+    }
+
+    #[test]
+    fn the_outline_scrolls_to_the_row_a_heading_was_drawn_on() {
+        // A source line and a rendered row are different numbers: the paragraph
+        // below wraps to several rows and the H1 gains a rule under it, so the
+        // second heading is drawn far below the line it lives on.
+        let vault = TempVault::new("outline-jump");
+        let prose = "a ".repeat(120);
+        vault.write("Deep.md", &format!("# One\n\n{prose}\n\n## Two\n\nend\n"));
+        let mut app = App::new(vault.vault(), Config::default()).expect("app");
+        let deep = app.index.id_of_rel("Deep.md").expect("indexed");
+        app.open_note(deep);
+
+        // Draw once, so the outline has a rendered layout to translate through.
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, 30)).expect("terminal");
+        terminal
+            .draw(|frame| crate::ui::draw(frame, &mut app))
+            .expect("frame");
+
+        app.side_panel = crate::app::SidePanel::Outline;
+        app.focus = Focus::Sidebar;
+        app.side_selected = 1;
+        let line = match &sidebar_targets(&app)[1] {
+            SidebarTarget::Heading(line) => *line,
+            other => panic!("expected a heading, got {other:?}"),
+        };
+        handle(&mut app, key(KeyCode::Enter));
+
+        let scroll = app.active().expect("tab").scroll;
+        assert!(
+            scroll > line,
+            "`## Two` is on source line {line} but was drawn further down; \
+             scrolled to {scroll}"
+        );
+    }
+
+    #[test]
+    fn the_outline_falls_back_to_the_line_before_anything_is_drawn() {
+        let (_v, mut app) = app();
+        let a = app.index.id_of_rel("A.md").expect("indexed");
+        app.open_note(a);
+
+        app.side_panel = crate::app::SidePanel::Outline;
+        app.focus = Focus::Sidebar;
+        handle(&mut app, key(KeyCode::Enter));
+
+        assert_eq!(app.active().expect("tab").scroll, 0, "no frame, no crash");
     }
 }
 

--- a/crates/otui/src/main.rs
+++ b/crates/otui/src/main.rs
@@ -375,9 +375,12 @@ fn handle_mouse(app: &mut App, mouse: crossterm::event::MouseEvent) -> bool {
             }
             handle_click(app, point)
         }
-        // Dragging a node pins it where you put it, which is how you untangle a
-        // knot of links that the layout has folded onto itself.
-        MouseEventKind::Drag(MouseButton::Left) => drag_graph_node(app, point),
+        // Dragging over text selects it; dragging a node pins it where you put
+        // it, which is how you untangle a knot of links that the layout has
+        // folded onto itself.
+        MouseEventKind::Drag(MouseButton::Left) => {
+            place_caret(app, point, true) || drag_graph_node(app, point)
+        }
         MouseEventKind::Up(MouseButton::Left) => release_graph_node(app),
         MouseEventKind::ScrollDown => handle_scroll(app, point, 3),
         MouseEventKind::ScrollUp => handle_scroll(app, point, -3),
@@ -528,6 +531,12 @@ fn handle_click(app: &mut App, point: (u16, u16)) -> bool {
         return true;
     }
 
+    // Clicking text puts the caret there, as it does in any editor.
+    if place_caret(app, point, false) {
+        app.focus = app::Focus::Note;
+        return true;
+    }
+
     // In the graph, a click selects the node nearest the pointer.
     if let Some((rect, x_bounds, y_bounds)) = app.regions.graph
         && hit(rect, point)
@@ -558,6 +567,35 @@ fn handle_click(app: &mut App, point: (u16, u16)) -> bool {
     false
 }
 
+/// Puts the caret where the editor was clicked, extending the selection when
+/// the pointer is being dragged.
+///
+/// Resolved against the text rectangle the last frame recorded, so a click lands
+/// on the character that was actually drawn there however the line wrapped.
+fn place_caret(app: &mut App, point: (u16, u16), extend: bool) -> bool {
+    let Some((rect, scroll)) = app.regions.editor else {
+        return false;
+    };
+    if !hit(rect, point) {
+        return false;
+    }
+    let wrap = app.config.editor.wrap;
+    let Some(editor) = app.editor_mut() else {
+        return false;
+    };
+
+    let layout = editor.layout(rect.width as usize, wrap);
+    let row = scroll + (point.1 - rect.y) as usize;
+    let column = (point.0 - rect.x) as usize + editor.hscroll;
+    editor.goto_visual(
+        &layout,
+        row,
+        u16::try_from(column).unwrap_or(u16::MAX),
+        extend,
+    );
+    true
+}
+
 /// Scrolls whichever pane is under the pointer, not whichever has focus.
 fn handle_scroll(app: &mut App, point: (u16, u16), delta: isize) -> bool {
     if let Some((rect, _)) = app.regions.explorer
@@ -572,6 +610,15 @@ fn handle_scroll(app: &mut App, point: (u16, u16), delta: isize) -> bool {
     {
         app.chat.follow = delta > 0;
         app.chat.scroll = (app.chat.scroll as isize + delta).max(0) as usize;
+        return true;
+    }
+    // While editing, the note's scroll offset lives on the editor — it counts
+    // wrapped rows, not lines — so the wheel has to move that one instead.
+    let editing = app
+        .active()
+        .is_some_and(|tab| tab.mode == app::Mode::Editing);
+    if editing && let Some(editor) = app.editor_mut() {
+        editor.scroll = (editor.scroll as isize + delta).max(0) as usize;
         return true;
     }
     match app.active_mut() {
@@ -636,6 +683,84 @@ mod tests {
                 modifiers: crossterm::event::KeyModifiers::empty(),
             },
         )
+    }
+
+    fn drag(app: &mut App, x: u16, y: u16) -> bool {
+        handle_mouse(
+            app,
+            MouseEvent {
+                kind: MouseEventKind::Drag(MouseButton::Left),
+                column: x,
+                row: y,
+                modifiers: crossterm::event::KeyModifiers::empty(),
+            },
+        )
+    }
+
+    /// A note long enough to scroll, opened in the editor and laid out once.
+    fn editing(app: &mut App) {
+        actions::dispatch(app, app::Action::ToggleMode);
+        lay_out(app);
+    }
+
+    #[test]
+    fn the_wheel_scrolls_the_editor_rather_than_the_reading_view() {
+        // The two keep separate offsets — the editor counts wrapped rows — and
+        // the wheel used to move the one the editor never reads, so it silently
+        // did nothing while editing.
+        let vault = TempVault::new("wheel");
+        let body: String = (0..200).map(|i| format!("line {i}\n")).collect();
+        vault.write("Long.md", &body);
+        let mut app = App::new(vault.vault(), Config::default()).expect("app");
+        let long = app.index.id_of_rel("Long.md").expect("indexed");
+        app.open_note(long);
+        editing(&mut app);
+
+        assert!(scroll(&mut app, 80, 20, false), "the wheel is handled");
+        assert_eq!(
+            app.editor_mut().expect("editor").scroll,
+            3,
+            "the editor scrolled"
+        );
+
+        scroll(&mut app, 80, 20, true);
+        assert_eq!(app.editor_mut().expect("editor").scroll, 0);
+        scroll(&mut app, 80, 20, true);
+        assert_eq!(
+            app.editor_mut().expect("editor").scroll,
+            0,
+            "and stops at the top"
+        );
+    }
+
+    #[test]
+    fn clicking_the_editor_puts_the_cursor_where_the_character_is() {
+        let (_v, mut app) = demo();
+        editing(&mut app);
+
+        let (text, _) = app.regions.editor.expect("the editor was drawn");
+        // Row 2 is `[[Beta]]`; column 4 is its third character.
+        click(&mut app, text.x + 4, text.y + 2);
+
+        let cursor = app.editor_mut().expect("editor").cursor();
+        assert_eq!(cursor.line, 2);
+        assert_eq!(cursor.col, 4);
+        assert_eq!(app.focus, app::Focus::Note);
+    }
+
+    #[test]
+    fn dragging_across_the_editor_selects_what_it_crosses() {
+        let (_v, mut app) = demo();
+        editing(&mut app);
+
+        let (text, _) = app.regions.editor.expect("the editor was drawn");
+        click(&mut app, text.x, text.y);
+        drag(&mut app, text.x + 5, text.y);
+
+        assert_eq!(
+            app.editor_mut().expect("editor").selected_text().as_deref(),
+            Some("# Alp")
+        );
     }
 
     /// The colour of the test picture. Half-blocks paint it into cell colours

--- a/crates/otui/src/ui/mod.rs
+++ b/crates/otui/src/ui/mod.rs
@@ -38,10 +38,15 @@ pub mod icons {
     pub const OUTLINE: &str = "▤";
     pub const CHAT: &str = "✦";
     pub const SETTINGS: &str = "⚙";
-    pub const BULLET: &str = "•";
-    pub const QUOTE_BAR: &str = "▎";
-    pub const TASK_DONE: &str = "☑";
-    pub const TASK_TODO: &str = "☐";
+    // Characters rather than strings: the editor swaps these in for the markers
+    // they stand for, one glyph for one character, so a styled line stays
+    // exactly as wide as the source it came from.
+    pub const BULLET: char = '•';
+    pub const QUOTE_BAR: char = '▎';
+    pub const TASK_DONE: char = '☑';
+    pub const TASK_TODO: char = '☐';
+    /// Marks a row that continues the one above it, drawn in the gutter.
+    pub const WRAP: char = '⤷';
     pub const SCROLL_THUMB: &str = "│";
     pub const IMAGE: &str = "▨";
 }
@@ -234,7 +239,9 @@ fn hints_for(app: &App) -> &'static [(&'static str, &'static str)] {
                     ("^S", "save"),
                     ("Esc", "read"),
                     ("^B/^I", "bold/italic"),
+                    ("Tab", "indent list"),
                     ("^Z", "undo"),
+                    ("click", "place cursor"),
                     ("^W", "close tab"),
                     ("^\\", "files"),
                     ("^]", "outline"),
@@ -463,7 +470,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, palette: &Palette, area: Rect) 
         Some(id) => {
             let words = app.index.note(id).map_or(0, |n| n.words);
             let backlinks = app.index.backlinks(id).len();
-            format!("{words} words  {backlinks} backlinks  ")
+            format!("{}{words} words  {backlinks} backlinks  ", position(app))
         }
         None => {
             let stats = app.index.stats();
@@ -482,6 +489,30 @@ fn draw_status_bar(frame: &mut Frame, app: &App, palette: &Palette, area: Rect) 
     Paragraph::new(Line::from(left))
         .style(Style::default().bg(palette.statusbar_bg))
         .render(area, frame.buffer_mut());
+}
+
+/// Where the cursor is, while editing. Empty the rest of the time.
+///
+/// A writer wants to know how far down a note they are, and it's the one number
+/// that tells you the caret you can see is the caret the buffer thinks it has.
+fn position(app: &App) -> String {
+    let Some(editor) = app.active().and_then(|tab| {
+        (tab.mode == crate::app::Mode::Editing)
+            .then_some(tab.editor.as_ref())
+            .flatten()
+    }) else {
+        return String::new();
+    };
+    let cursor = editor.cursor();
+    let selected = editor.selected_text().map_or(String::new(), |text| {
+        format!("{} selected  ", text.chars().count())
+    });
+    format!(
+        "{selected}Ln {}/{}, Col {}  ",
+        cursor.line + 1,
+        editor.line_count(),
+        cursor.col + 1
+    )
 }
 
 fn mode_label(app: &App) -> String {
@@ -1116,6 +1147,178 @@ mod tests {
         let screen = render(&mut app, 120, 30).join("\n");
         assert!(screen.contains("# Welcome"), "editing shows the source");
         assert!(screen.contains(" 1 "), "line numbers");
+    }
+
+    /// The note pane, without the chrome around it, as the user sees it.
+    fn note_pane(app: &mut App, width: u16, height: u16) -> Vec<String> {
+        let rows = render(app, width, height);
+        let left = app.regions.main.map_or(0, |rect| rect.x) as usize;
+        rows.iter()
+            .map(|row| row.chars().skip(left).collect::<String>())
+            .collect()
+    }
+
+    #[test]
+    fn a_long_line_wraps_instead_of_being_cut_off() {
+        // The bug this fixes: a line wider than the pane was clipped at the edge
+        // and, with no way to scroll sideways either, simply unreachable.
+        let vault = TempVault::new("render-wrap");
+        let sentence = "alpha bravo charlie delta echo foxtrot golf hotel india juliet";
+        vault.write("Long.md", &format!("{sentence}\n"));
+
+        let mut app = App::new(vault.vault(), Config::default()).expect("app");
+        let long = app.index.id_of_rel("Long.md").expect("indexed");
+        app.open_note(long);
+        crate::actions::dispatch(&mut app, crate::app::Action::ToggleMode);
+
+        let rows = note_pane(&mut app, 60, 20);
+        let shown: String = rows.join(" ");
+        for word in sentence.split(' ') {
+            assert!(shown.contains(word), "{word:?} was cut off: {rows:?}");
+        }
+        assert!(
+            rows.iter().filter(|row| row.contains("alpha")).count() == 1,
+            "and it is drawn once, not repeated"
+        );
+    }
+
+    #[test]
+    fn switching_modes_does_not_reflow_the_prose() {
+        // The prose column has to sit in the same place with the same width in
+        // both modes, or Ctrl+E rewraps the paragraph under the reader's eyes.
+        let vault = TempVault::new("render-reflow");
+        let sentence = "one two three four five six seven eight nine ten eleven twelve";
+        vault.write("Prose.md", &format!("{sentence}\n"));
+
+        let mut app = App::new(vault.vault(), Config::default()).expect("app");
+        let prose = app.index.id_of_rel("Prose.md").expect("indexed");
+        app.open_note(prose);
+
+        let reading = note_pane(&mut app, 46, 12);
+        crate::actions::dispatch(&mut app, crate::app::Action::ToggleMode);
+        let editing = note_pane(&mut app, 46, 12);
+
+        // Keep only the prose: the gutter carries a line number or a wrap marker
+        // while editing, and the hint and status bars legitimately differ.
+        let broke_as = |rows: &[String]| -> Vec<String> {
+            rows.iter()
+                .map(|row| {
+                    row.split_whitespace()
+                        .filter(|word| sentence.split(' ').any(|prose| prose == *word))
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                })
+                .filter(|row| !row.is_empty())
+                .collect()
+        };
+        let reading = broke_as(&reading);
+        assert!(reading.len() > 1, "the sentence should wrap at this width");
+        assert_eq!(
+            reading,
+            broke_as(&editing),
+            "the same words broke in different places"
+        );
+    }
+
+    /// Draws a frame and reports where the terminal caret ended up.
+    ///
+    /// A frame that asks for no caret leaves the backend's position alone, so
+    /// comparing across two draws says whether one was drawn at all.
+    fn caret_after(terminal: &mut Terminal<TestBackend>, app: &mut App) -> (u16, u16) {
+        use ratatui::backend::Backend;
+
+        terminal.draw(|frame| draw(frame, app)).expect("draw");
+        let position = terminal
+            .backend_mut()
+            .get_cursor_position()
+            .expect("cursor position");
+        (position.x, position.y)
+    }
+
+    #[test]
+    fn the_caret_follows_the_cursor_onto_a_wrapped_row() {
+        // Counting characters put the caret past the pane on a long line; it has
+        // to follow the row the character was actually drawn on.
+        let vault = TempVault::new("caret-wrap");
+        vault.write("Long.md", &format!("{}\n", "word ".repeat(40)));
+        let mut app = App::new(vault.vault(), Config::default()).expect("app");
+        let long = app.index.id_of_rel("Long.md").expect("indexed");
+        app.open_note(long);
+        crate::actions::dispatch(&mut app, crate::app::Action::ToggleMode);
+
+        let mut terminal = Terminal::new(TestBackend::new(90, 24)).expect("terminal");
+        terminal.draw(|frame| draw(frame, &mut app)).expect("draw");
+        let (text, _) = app.regions.editor.expect("the editor was drawn");
+
+        // Character 150 of one long line is well past the pane's width.
+        app.editor_mut().expect("editor").goto(0, 150);
+        let (x, y) = caret_after(&mut terminal, &mut app);
+
+        assert!(
+            x < text.x + text.width,
+            "the caret sat at column {x}, outside a pane {} wide",
+            text.width
+        );
+        assert!(y > text.y, "and on a later row, since the line wrapped");
+    }
+
+    #[test]
+    fn no_caret_is_drawn_when_the_note_pane_is_not_focused() {
+        // Otherwise the note claims a caret that belongs to whatever pane is
+        // actually taking the keys.
+        let (_vault, mut app) = demo_app();
+        app.config.ui.show_chat = false;
+        crate::actions::dispatch(&mut app, crate::app::Action::ToggleMode);
+
+        let mut terminal = Terminal::new(TestBackend::new(120, 30)).expect("terminal");
+        let focused = caret_after(&mut terminal, &mut app);
+
+        // Move the cursor somewhere else, then hand the keys to another pane. A
+        // note pane still drawing a caret would move it; one that isn't cannot.
+        app.editor_mut().expect("editor").goto(4, 3);
+        app.focus = Focus::Explorer;
+        assert_eq!(
+            caret_after(&mut terminal, &mut app),
+            focused,
+            "the note pane drew a caret while the explorer had the keys"
+        );
+
+        app.focus = Focus::Note;
+        assert_ne!(
+            caret_after(&mut terminal, &mut app),
+            focused,
+            "and draws one again when it gets them back"
+        );
+    }
+
+    #[test]
+    fn editing_shows_markdown_styled_without_moving_it() {
+        // Live preview in a character grid: the bullet is drawn as one, but it
+        // still occupies the single column the `-` did, so the caret can't drift.
+        let (_vault, mut app) = demo_app();
+        crate::actions::dispatch(&mut app, crate::app::Action::ToggleMode);
+        let rows = note_pane(&mut app, 120, 30);
+
+        let task = rows
+            .iter()
+            .find(|row| row.contains("a task"))
+            .expect("the task line");
+        assert!(
+            task.contains(&format!("{} [ ] a task", icons::BULLET)),
+            "the marker is styled in place: {task:?}"
+        );
+        assert!(
+            rows.iter().any(|row| row.contains(&format!(
+                "{} [{}] a done task",
+                icons::BULLET,
+                icons::TASK_DONE
+            ))),
+            "a done task shows a ticked box: {rows:?}"
+        );
+        assert!(
+            rows.iter().any(|row| row.contains("```rust")),
+            "and a code fence is still literally what it says"
+        );
     }
 
     #[test]

--- a/crates/otui/src/ui/modal.rs
+++ b/crates/otui/src/ui/modal.rs
@@ -250,6 +250,27 @@ const HELP: &[(&str, &[(&str, &str)])] = &[
         ],
     ),
     (
+        "Editing a note",
+        &[
+            ("↑ / ↓", "Up and down a line as it's wrapped on screen"),
+            ("Home / End", "Start and end of the line on screen"),
+            (
+                "Enter",
+                "New line, carrying a list marker; twice ends the list",
+            ),
+            (
+                "Tab / Shift+Tab",
+                "Nest or unnest a list item; a tab in prose",
+            ),
+            ("click / drag", "Place the cursor / select text"),
+            ("Ctrl+Space", "Start a selection without holding Shift"),
+            ("Ctrl+A", "Select the whole note"),
+            ("Ctrl+Shift+K", "Delete the line"),
+            ("Ctrl+←/→", "By word"),
+            ("Ctrl+Home / End", "Start and end of the note"),
+        ],
+    ),
+    (
         "File explorer",
         &[
             ("Enter / l", "Open the note, or fold the folder"),

--- a/crates/otui/src/ui/note.rs
+++ b/crates/otui/src/ui/note.rs
@@ -20,11 +20,21 @@ use otui_core::markdown::{self, Align, Block, BlockKind, Marker, SpanKind, Table
 use otui_theme::Palette;
 
 use crate::app::{App, Mode, Regions};
+use crate::editor::{Cursor, Row};
 use crate::images::{self, Images};
 use crate::ui::{drawing, icons, scrollbar, truncate};
 
 /// Left padding inside the note pane, matching Obsidian's generous margins.
 const PADDING: u16 = 2;
+
+/// Columns reserved for the line-number gutter when it is switched on.
+///
+/// Fixed rather than sized to the note, and reserved while *reading* too, where
+/// it is left blank. Both modes then wrap the same prose to the same width in
+/// the same column, which is what makes `Ctrl+E` restyle the page instead of
+/// reflowing it. A note past 999 lines spends the separating space on a fourth
+/// digit rather than moving the text.
+const GUTTER: u16 = 4;
 
 /// Widest a single table column may be drawn, in characters.
 ///
@@ -50,6 +60,13 @@ pub struct Ctx<'a> {
     pub images: Option<&'a mut Images>,
     /// Where each picture ended up, filled in as blocks are laid out.
     pub pictures: Vec<Picture>,
+    /// Which rendered row each block's source line ended up on, filled in as
+    /// blocks are laid out.
+    ///
+    /// A source line and a rendered row are not the same number — prose wraps,
+    /// headings gain a rule, a picture takes a dozen rows — so scrolling to a
+    /// heading the outline points at needs the translation written down.
+    pub anchors: Vec<(usize, usize)>,
 }
 
 impl<'a> Ctx<'a> {
@@ -63,6 +80,7 @@ impl<'a> Ctx<'a> {
             note_dir: None,
             images: None,
             pictures: Vec::new(),
+            anchors: Vec::new(),
         }
     }
 }
@@ -108,11 +126,40 @@ pub fn draw(
         return;
     }
 
+    // Reserved in both modes so the prose column never moves between them.
+    let gutter = if app.config.ui.line_numbers {
+        GUTTER.min(body.width)
+    } else {
+        0
+    };
+
     match app.active().map(|t| t.mode) {
-        Some(Mode::Reading) => draw_reading(frame, app, palette, body),
-        Some(Mode::Editing) => draw_editing(frame, app, palette, body),
+        Some(Mode::Reading) => draw_reading(frame, app, palette, body, gutter, regions),
+        Some(Mode::Editing) => draw_editing(frame, app, palette, body, gutter, regions),
         None => {}
     }
+}
+
+/// The prose column inside the note pane: the gutter and the scrollbar's column
+/// taken off.
+fn prose_area(area: Rect, gutter: u16) -> Rect {
+    Rect {
+        x: area.x + gutter,
+        y: area.y,
+        width: area.width.saturating_sub(gutter),
+        height: area.height,
+    }
+}
+
+/// Width and height the editor's text was last drawn at.
+///
+/// Key handling needs it to move between wrapped rows, and reads it from the
+/// last frame rather than recomputing the layout arithmetic a second time.
+#[must_use]
+pub fn edit_viewport(app: &App) -> (usize, usize) {
+    app.regions.editor.map_or((0, 0), |(rect, _)| {
+        (rect.width as usize, rect.height as usize)
+    })
 }
 
 fn draw_tab_bar(
@@ -217,12 +264,22 @@ fn draw_empty_state(frame: &mut Frame, palette: &Palette, area: Rect) {
 // Reading mode
 // ---------------------------------------------------------------------------
 
-fn draw_reading(frame: &mut Frame, app: &mut App, palette: &Palette, area: Rect) {
+fn draw_reading(
+    frame: &mut Frame,
+    app: &mut App,
+    palette: &Palette,
+    area: Rect,
+    gutter: u16,
+    regions: &mut Regions,
+) {
     let Some(id) = app.active_note() else { return };
     let Ok(content) = app.index.read(id) else {
         Paragraph::new("could not read this note").render(area, frame.buffer_mut());
         return;
     };
+    // The scrollbar stays on the pane's edge; the prose sits inside the gutter.
+    let full = area;
+    let area = prose_area(area, gutter);
 
     // An Excalidraw note is a wrapper around a scene: its Markdown is a warning
     // banner and a wall of compressed base64, and the drawing is the content.
@@ -261,9 +318,11 @@ fn draw_reading(frame: &mut Frame, app: &mut App, palette: &Palette, area: Rect)
         note_dir,
         images: Some(&mut app.images),
         pictures: Vec::new(),
+        anchors: Vec::new(),
     };
     let lines = render_document(&document, &mut ctx, width);
     let pictures = std::mem::take(&mut ctx.pictures);
+    regions.anchors = std::mem::take(&mut ctx.anchors);
 
     let height = area.height as usize;
     let max_scroll = lines.len().saturating_sub(height);
@@ -290,7 +349,7 @@ fn draw_reading(frame: &mut Frame, app: &mut App, palette: &Palette, area: Rect)
         scroll,
         hscroll,
     );
-    scrollbar(frame, palette, area, scroll, lines.len());
+    scrollbar(frame, palette, full, scroll, lines.len());
 }
 
 /// Draws the pictures whose rows are on screen, over the blanks left for them.
@@ -369,9 +428,23 @@ pub fn render_document(
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     for block in &document.blocks {
+        ctx.anchors.push((block.line, lines.len()));
         render_block(block, ctx, width, 0, &mut lines);
     }
     lines
+}
+
+/// The rendered row a source line was drawn on.
+///
+/// Only block starts are recorded, so a line inside a block resolves to the row
+/// its block began on — which is what scrolling to a heading wants anyway.
+#[must_use]
+pub fn anchor_row(anchors: &[(usize, usize)], line: usize) -> usize {
+    anchors
+        .iter()
+        .take_while(|(source, _)| *source <= line)
+        .last()
+        .map_or(line, |(_, row)| *row)
 }
 
 fn render_block(
@@ -714,27 +787,7 @@ fn style_spans(
                 SpanKind::Text => {}
             }
 
-            if span.style.code {
-                style = style.fg(palette.code_fg).bg(palette.code_bg);
-            }
-            if span.style.bold {
-                style = style.fg(palette.bold).add_modifier(Modifier::BOLD);
-            }
-            if span.style.italic {
-                style = style.add_modifier(Modifier::ITALIC);
-            }
-            if span.style.strikethrough {
-                style = style
-                    .fg(palette.strikethrough)
-                    .add_modifier(Modifier::CROSSED_OUT);
-            }
-            if span.style.highlight {
-                style = style
-                    .bg(palette.text_highlight_bg)
-                    .fg(palette.text_highlight_fg);
-            }
-
-            (span.text.clone(), style)
+            (span.text.clone(), emphasis(style, span.style, palette))
         })
         .collect()
 }
@@ -1050,102 +1103,430 @@ fn capitalize(text: &str) -> String {
 // Editing mode
 // ---------------------------------------------------------------------------
 
-fn draw_editing(frame: &mut Frame, app: &mut App, palette: &Palette, area: Rect) {
-    let show_numbers = app.config.ui.line_numbers;
+fn draw_editing(
+    frame: &mut Frame,
+    app: &mut App,
+    palette: &Palette,
+    area: Rect,
+    gutter: u16,
+    regions: &mut Regions,
+) {
+    let wrap = app.config.editor.wrap;
+    // A caret in an unfocused pane claims input that would go somewhere else.
+    let focused = app.focus == crate::app::Focus::Note;
+    let prose = prose_area(area, gutter);
+    // One column is left for the scrollbar, which also gives the caret a place
+    // to sit at the end of a full row.
+    let text = Rect {
+        width: prose.width.saturating_sub(1),
+        ..prose
+    };
+    let height = text.height as usize;
+
     let Some(editor) = app.editor_mut() else {
         return;
     };
+    let layout = editor.layout(text.width as usize, wrap);
+    editor.scroll_into_view(&layout, height);
 
-    let height = area.height as usize;
-    editor.scroll_into_view(height);
     let scroll = editor.scroll;
-    let cursor = editor.cursor();
-    let total = editor.line_count();
-
-    let gutter = if show_numbers {
-        (total.to_string().len() + 2) as u16
-    } else {
-        0
-    };
-    let text_width = area.width.saturating_sub(gutter + 1) as usize;
-
+    let hscroll = editor.hscroll;
+    let (caret_row, caret_column) = editor.caret(&layout);
     let selection = editor.selection();
-    let mut lines: Vec<Line> = Vec::new();
+    let cursor_line = editor.cursor().line;
+    let fenced = fenced_lines(editor.lines());
 
-    for (offset, text) in editor.lines().iter().enumerate().skip(scroll).take(height) {
-        let is_cursor_line = offset == cursor.line;
-        let mut spans = Vec::new();
+    // Painting a whole source line at once and slicing it per row keeps one
+    // decision — what each character is — in one place, however it wrapped.
+    let mut painted: Option<(usize, Vec<(char, Style)>)> = None;
+    let mut numbers: Vec<Line> = Vec::new();
+    let mut body: Vec<Line> = Vec::new();
 
-        if show_numbers {
-            spans.push(Span::styled(
-                format!("{:>width$}  ", offset + 1, width = gutter as usize - 2),
-                Style::default().fg(if is_cursor_line {
-                    palette.line_number_active
-                } else {
-                    palette.line_number
-                }),
+    for row in layout.rows().iter().skip(scroll).take(height) {
+        let on_cursor_line = row.line == cursor_line;
+        numbers.push(gutter_line(row, on_cursor_line, gutter, palette));
+
+        if painted.as_ref().is_none_or(|(line, _)| *line != row.line) {
+            let source = &editor.lines()[row.line];
+            painted = Some((
+                row.line,
+                paint_line(source, on_cursor_line, fenced[row.line], palette),
             ));
         }
+        let Some((_, chars)) = &painted else { continue };
 
-        let base = Style::default()
-            .fg(palette.text_normal)
-            .bg(if is_cursor_line {
-                palette.cursor_line_bg
-            } else {
-                palette.bg_primary
-            });
-
-        // Selection is painted per character so it survives wrapping and
-        // multi-byte text without a second layout pass.
-        let chars: Vec<char> = text.chars().collect();
-        let mut run = String::new();
-        let mut run_selected = false;
-
-        for (col, ch) in chars.iter().enumerate() {
-            let selected = selection.is_some_and(|(start, end)| {
-                let position = (offset, col);
-                position >= (start.line, start.col) && position < (end.line, end.col)
-            });
-            if selected != run_selected && !run.is_empty() {
-                spans.push(Span::styled(
-                    std::mem::take(&mut run),
-                    if run_selected {
-                        base.bg(palette.bg_selection)
-                    } else {
-                        base
-                    },
-                ));
-            }
-            run_selected = selected;
-            run.push(*ch);
-        }
-        if !run.is_empty() {
-            spans.push(Span::styled(
-                run,
-                if run_selected {
-                    base.bg(palette.bg_selection)
+        body.push(row_line(
+            row,
+            &chars[row.start.min(chars.len())..row.end.min(chars.len())],
+            RowStyle {
+                background: if fenced[row.line] {
+                    palette.code_bg
+                } else if on_cursor_line {
+                    palette.cursor_line_bg
                 } else {
-                    base
+                    palette.bg_primary
                 },
-            ));
-        }
-
-        if spans.len() <= usize::from(show_numbers) {
-            spans.push(Span::styled(String::new(), base));
-        }
-
-        lines.push(Line::from(spans));
+                selection: palette.bg_selection,
+            },
+            selection,
+            text.width as usize + hscroll,
+        ));
     }
 
-    Paragraph::new(lines).render(area, frame.buffer_mut());
-    scrollbar(frame, palette, area, scroll, total);
+    if gutter > 0 {
+        Paragraph::new(numbers).render(
+            Rect {
+                width: gutter,
+                ..area
+            },
+            frame.buffer_mut(),
+        );
+    }
+    Paragraph::new(body)
+        .scroll((0, u16::try_from(hscroll).unwrap_or(u16::MAX)))
+        .render(text, frame.buffer_mut());
+    scrollbar(frame, palette, area, scroll, layout.rows().len());
+
+    regions.editor = Some((text, scroll));
 
     // Place the terminal cursor so the user sees a real caret.
-    let cursor_row = cursor.line.saturating_sub(scroll);
-    if cursor_row < height {
-        let x = area.x + gutter + cursor.col.min(text_width) as u16;
-        frame.set_cursor_position((x, area.y + cursor_row as u16));
+    let column = usize::from(caret_column);
+    if focused && caret_row >= scroll && caret_row - scroll < height && column >= hscroll {
+        let x = text.x + u16::try_from(column - hscroll).unwrap_or(u16::MAX);
+        if x < prose.x + prose.width {
+            frame.set_cursor_position((x, text.y + (caret_row - scroll) as u16));
+        }
     }
+}
+
+/// Colours for the row a line is drawn on, behind whatever it says.
+struct RowStyle {
+    background: ratatui::style::Color,
+    selection: ratatui::style::Color,
+}
+
+/// The gutter cell for one row: a line number, or the wrap marker on a row that
+/// is the continuation of the one above.
+///
+/// The marker lives here rather than in the text so that distinguishing a soft
+/// wrap from a real line break costs no reading width at all.
+fn gutter_line(row: &Row, on_cursor_line: bool, gutter: u16, palette: &Palette) -> Line<'static> {
+    if gutter == 0 {
+        return Line::from("");
+    }
+    let width = usize::from(gutter) - 1;
+    let (text, color) = if row.first {
+        (
+            format!("{:>width$} ", row.line + 1),
+            if on_cursor_line {
+                palette.line_number_active
+            } else {
+                palette.line_number
+            },
+        )
+    } else {
+        (format!("{:>width$} ", icons::WRAP), palette.text_faint)
+    };
+    Line::from(Span::styled(text, Style::default().fg(color)))
+}
+
+/// Builds one terminal row from the painted characters it shows.
+///
+/// The row is padded to the full width so a code block's background and the
+/// cursor line's highlight reach the edge of the pane rather than stopping at
+/// the end of the text.
+fn row_line(
+    row: &Row,
+    chars: &[(char, Style)],
+    colors: RowStyle,
+    selection: Option<(Cursor, Cursor)>,
+    width: usize,
+) -> Line<'static> {
+    let selected = |col: usize| {
+        selection.is_some_and(|(start, end)| {
+            let at = (row.line, col);
+            at >= (start.line, start.col) && at < (end.line, end.col)
+        })
+    };
+    // A background already on the character — inline code — outranks the row's,
+    // and a selection outranks both.
+    let resolve = |style: Style, col: usize| {
+        if selected(col) {
+            return style.bg(colors.selection);
+        }
+        match style.bg {
+            Some(_) => style,
+            None => style.bg(colors.background),
+        }
+    };
+
+    let mut spans = vec![Span::styled(
+        " ".repeat(usize::from(row.indent)),
+        Style::default().bg(colors.background),
+    )];
+    let mut run = String::new();
+    let mut current: Option<Style> = None;
+
+    for (offset, (ch, style)) in chars.iter().enumerate() {
+        let style = resolve(*style, row.start + offset);
+        if current.is_some_and(|open| open != style) {
+            spans.push(Span::styled(std::mem::take(&mut run), current.unwrap()));
+        }
+        current = Some(style);
+        run.push(*ch);
+    }
+    if let Some(style) = current {
+        spans.push(Span::styled(run, style));
+    }
+
+    // Trailing fill, including the selected newline at the end of a line the
+    // selection runs through.
+    let used: usize = spans.iter().map(Span::width).sum();
+    let end = selected(row.end).then_some(colors.selection);
+    if let Some(color) = end {
+        spans.push(Span::styled(" ", Style::default().bg(color)));
+    }
+    let pad = width.saturating_sub(used + usize::from(end.is_some()));
+    spans.push(Span::styled(
+        " ".repeat(pad),
+        Style::default().bg(colors.background),
+    ));
+    Line::from(spans)
+}
+
+/// Which lines sit inside a fenced code block, so their content is never read
+/// as Markdown while it is being edited.
+fn fenced_lines(lines: &[String]) -> Vec<bool> {
+    let mut inside = false;
+    lines
+        .iter()
+        .map(|line| {
+            let trimmed = line.trim_start();
+            let fence = trimmed.starts_with("```") || trimmed.starts_with("~~~");
+            // The fence lines belong to the block they open and close.
+            let fenced = inside || fence;
+            inside ^= fence;
+            fenced
+        })
+        .collect()
+}
+
+/// Styles one source line character by character, ready to be sliced across
+/// however many rows it wrapped onto.
+///
+/// Markers are dimmed and given the glyph the reading pane would use, but only
+/// where that glyph is exactly as wide as what it replaces — a `-` becomes a
+/// `•`, an `x` inside `[x]` becomes a `☑`. Nothing is hidden and nothing moves,
+/// so the caret is always where the character is, and `on_cursor_line` can show
+/// the line exactly as typed without the text shifting underneath.
+fn paint_line(
+    text: &str,
+    on_cursor_line: bool,
+    fenced: bool,
+    palette: &Palette,
+) -> Vec<(char, Style)> {
+    let chars: Vec<char> = text.chars().collect();
+    if fenced {
+        let style = Style::default().fg(palette.code_fg).bg(palette.code_bg);
+        return chars.into_iter().map(|ch| (ch, style)).collect();
+    }
+
+    let mut out: Vec<(char, Style)> = markdown::scan_inline(text)
+        .into_iter()
+        .zip(&chars)
+        .map(|(paint, ch)| (*ch, paint_style(paint, on_cursor_line, palette)))
+        .collect();
+
+    decorate_markers(&chars, on_cursor_line, palette, &mut out);
+    out
+}
+
+/// Theme colors for one inline character of source.
+fn paint_style(paint: markdown::Paint, on_cursor_line: bool, palette: &Palette) -> Style {
+    use markdown::Ink;
+
+    let mut style = Style::default().fg(match paint.ink {
+        // On the cursor's own line the syntax is what you are editing, so it is
+        // shown at full contrast rather than pushed into the background.
+        Ink::Marker if on_cursor_line => palette.text_muted,
+        Ink::Marker => palette.text_faint,
+        // Whether a link resolves is the reading pane's business: it has the
+        // link target, and this only has the characters.
+        Ink::WikiLink => palette.link,
+        Ink::Link => palette.link_external,
+        Ink::Tag => palette.tag_fg,
+        Ink::Math => palette.text_accent,
+        Ink::Text => palette.text_normal,
+    });
+    if paint.ink == Ink::Tag {
+        style = style.bg(palette.tag_bg);
+    }
+    emphasis(style, paint.style, palette)
+}
+
+/// Applies bold, italic, strikethrough, inline code and highlight colors.
+///
+/// Shared with the reading pane so a bold word can't end up a different color
+/// depending on which mode you are looking at it in.
+fn emphasis(mut style: Style, md: markdown::Style, palette: &Palette) -> Style {
+    if md.code {
+        style = style.fg(palette.code_fg).bg(palette.code_bg);
+    }
+    if md.bold {
+        style = style.fg(palette.bold).add_modifier(Modifier::BOLD);
+    }
+    if md.italic {
+        style = style.add_modifier(Modifier::ITALIC);
+    }
+    if md.strikethrough {
+        style = style
+            .fg(palette.strikethrough)
+            .add_modifier(Modifier::CROSSED_OUT);
+    }
+    if md.highlight {
+        style = style
+            .bg(palette.text_highlight_bg)
+            .fg(palette.text_highlight_fg);
+    }
+    style
+}
+
+/// Restyles a line's leading Markdown marker, and swaps in the glyph the
+/// reading pane uses wherever it is exactly as wide.
+fn decorate_markers(
+    chars: &[char],
+    on_cursor_line: bool,
+    palette: &Palette,
+    out: &mut [(char, Style)],
+) {
+    let indent = chars
+        .iter()
+        .take_while(|ch| **ch == ' ' || **ch == '\t')
+        .count();
+    let rest: String = chars[indent..].iter().collect();
+    let at = |offset: usize| indent + offset;
+
+    // A heading keeps its hashes, dimmed, and colors its title.
+    let hashes = rest.chars().take_while(|ch| *ch == '#').count();
+    if (1..=6).contains(&hashes) && rest.chars().nth(hashes) == Some(' ') {
+        let level = u8::try_from(hashes).unwrap_or(6);
+        let title = Style::default()
+            .fg(palette.heading(level))
+            .add_modifier(Modifier::BOLD);
+        for entry in out.iter_mut().skip(at(hashes + 1)) {
+            entry.1 = title;
+        }
+        return;
+    }
+
+    // `- [x] `: color the box, tick it, and strike the item through.
+    if let Some(checked) = task(&rest) {
+        let color = if checked {
+            palette.checkbox_done
+        } else {
+            palette.checkbox_todo
+        };
+        substitute(out, at(0), bullet_glyph(on_cursor_line), color);
+        for offset in [2, 4] {
+            if let Some(entry) = out.get_mut(at(offset)) {
+                entry.1 = Style::default().fg(palette.text_faint);
+            }
+        }
+        let tick = if checked { icons::TASK_DONE } else { ' ' };
+        substitute(out, at(3), (!on_cursor_line).then_some(tick), color);
+        if checked {
+            for entry in out.iter_mut().skip(at(6)) {
+                entry.1 = entry
+                    .1
+                    .fg(palette.text_faint)
+                    .add_modifier(Modifier::CROSSED_OUT);
+            }
+        }
+        return;
+    }
+
+    if matches!(rest.as_bytes().first(), Some(b'-' | b'*' | b'+'))
+        && rest.as_bytes().get(1) == Some(&b' ')
+    {
+        substitute(
+            out,
+            at(0),
+            bullet_glyph(on_cursor_line),
+            palette.list_marker,
+        );
+        return;
+    }
+
+    // `1. ` keeps its number; only the color says it is a marker.
+    let digits = rest.chars().take_while(char::is_ascii_digit).count();
+    if digits > 0
+        && matches!(rest.as_bytes().get(digits), Some(b'.' | b')'))
+        && rest.as_bytes().get(digits + 1) == Some(&b' ')
+    {
+        for entry in out.iter_mut().skip(indent).take(digits + 1) {
+            entry.1 = Style::default().fg(palette.list_marker);
+        }
+        return;
+    }
+
+    // Every `>` of a quote, at every level, becomes the bar the reading pane
+    // draws — and the body it introduces is tinted to match.
+    if rest.starts_with('>') {
+        let prefix = rest
+            .bytes()
+            .take_while(|b| matches!(b, b'>' | b' '))
+            .count();
+        for offset in 0..prefix {
+            if chars.get(at(offset)) == Some(&'>') {
+                substitute(
+                    out,
+                    at(offset),
+                    (!on_cursor_line).then_some(icons::QUOTE_BAR),
+                    palette.quote_bar,
+                );
+            }
+        }
+        for entry in out.iter_mut().skip(at(prefix)) {
+            if entry.1.fg == Some(palette.text_normal) {
+                entry.1 = entry.1.fg(palette.quote_fg);
+            }
+        }
+    }
+}
+
+/// The glyph a list bullet is drawn as, or nothing on the cursor's own line
+/// where the character as typed is what matters.
+fn bullet_glyph(on_cursor_line: bool) -> Option<char> {
+    (!on_cursor_line).then_some(icons::BULLET)
+}
+
+/// Recolors one character, optionally drawing a different glyph in its place.
+///
+/// Only ever called with a replacement the same width as the original, so the
+/// column a character occupies never depends on how it is styled.
+fn substitute(
+    out: &mut [(char, Style)],
+    at: usize,
+    glyph: Option<char>,
+    color: ratatui::style::Color,
+) {
+    if let Some(entry) = out.get_mut(at) {
+        if let Some(glyph) = glyph {
+            entry.0 = glyph;
+        }
+        entry.1 = Style::default().fg(color);
+    }
+}
+
+/// Whether a line is a task, and whether it is done.
+fn task(rest: &str) -> Option<bool> {
+    let bytes = rest.as_bytes();
+    let valid = matches!(bytes.first(), Some(b'-' | b'*' | b'+'))
+        && bytes.get(1) == Some(&b' ')
+        && bytes.get(2) == Some(&b'[')
+        && bytes.get(4) == Some(&b']')
+        && bytes.get(5) == Some(&b' ');
+    valid.then(|| matches!(bytes.get(3), Some(b'x' | b'X')))
 }
 
 #[cfg(test)]
@@ -1227,6 +1608,7 @@ mod tests {
             note_dir: None,
             images: Some(images),
             pictures: Vec::new(),
+            anchors: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Release 0.3.0 — an editor you can actually write in

Long lines were cut off at the edge of the pane while editing, and with no way to pan sideways the rest of them was unreachable. `editor.wrap` had been written into every user's config since the first release, documented as doing exactly this, and read by nothing.

### Wrapping, and the four things that depended on rows == lines

Wrapping means a source line and a terminal row stop being the same number. The buffer keeps its line-oriented model — the parser and the index both read it — and a separate `Layout` maps lines onto rows. It's rebuilt where needed rather than cached: one pass over the text, and no way to draw a stale note.

- **Caret** — was positioned by counting characters then clamped to the pane, so on a long line it parked at the right margin and lied, and on any line with a CJK character or emoji (two columns wide, one character) it was simply wrong. It now maps through the layout the text was drawn with, so arrow keys, clicks and drags all land on the character under them.
- **Scrolling / scrollbar** — now row-based.
- **Outline jump** — scrolled to a heading's line number in the file, but that offset counts rendered rows. The further down you jumped, the further off you landed.

### Live styling while editing

Markdown is styled as you type, not only once you stop. Nothing is hidden: every substituted glyph is exactly as wide as the character it replaces, so a bullet drawn as a dot still occupies the hyphen's column and the caret can't drift. Hiding syntax the way Obsidian's live preview does would need a source range on every inline span, rippling into the reading pane, index, outline and agent summaries — and it reads badly in a character grid anyway, since text slides sideways and re-wraps as the cursor moves between lines. The cursor's own line shows its markers at full contrast; widths match, so nothing moves as the cursor arrives or leaves.

### Consistent wrap width across modes

Reading laid prose out from the pane's left edge while editing started after the line-number gutter, so the same paragraph wrapped differently in each mode and every line broke somewhere else on the way in and out. The gutter's width is reserved in both modes now, left blank while reading. Defaulting line numbers off would have fixed nothing for existing users — `ensure_exists` wrote `line_numbers = true` into their config on first run.

### Three more defects found while tracing those

- The mouse wheel did nothing while editing — it moved the reading view's offset, which the editor never reads.
- A caret was drawn in the note pane while keys belonged to the chat panel or the explorer.
- The outline jump offset bug above.

Each has a test that fails without its fix.

### List editing

Enter carries a list marker onto the next line and ends the list when pressed on an empty item. Tab and Shift+Tab nest and unnest an item — Shift+Tab did nothing at all before.

### Also in this branch

- Move to the 2024 edition
- Collapse nested conditionals into let-chains
- Stop writing to the environment from tests (`set_var` is unsafe in 2024)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
