### PR TITLE
Drop the empty Unreleased heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [0.3.0] — 2026-08-05
 
 The release that makes the editor usable for actually writing in: text wraps,


### PR DESCRIPTION
`## [Unreleased]` sat above `## [0.3.0]` with nothing under it. Because `release.yml` uses `body_path: CHANGELOG.md`, it was also rendering on the published v0.3.0 release page, directly above the 0.3.0 heading — reading as though the release were unreleased.

Two lines removed. There was no `[Unreleased]:` link definition at the bottom of the file to clean up, and no other occurrence of the word remains.

The published v0.3.0 release body has been edited separately to drop the same heading, since it was generated from this file at tag time and doesn't regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)