### PR TITLE
Put Inter back, and keep the mono for code

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap">
 <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -35,7 +35,7 @@
   --t-purple:  #a882ff;
   --t-on-acc:  #ffffff;
 
-  --sans: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
 
   --r-sm: 8px;


### PR DESCRIPTION
Reverts only the font half of #10.

`--sans` points at Inter again, so the prose is set in a text face; JetBrains
Mono goes back to the job it already had, via the seven rules that reference
`--mono`: `code`/`kbd`/`pre`, the install command in the hero, the keys table,
and the small labels around the graph. The Google Fonts request asks for both
families again, at the weights they were on before.

Everything else from #10 stays: no em dashes, the hero reads "without leaving
the terminal", and the screenshots remain folded into the features section.

Two files, one line each.