### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] — 2026-08-07
+
+A packaging release. Nothing about using the app has changed.
+
+### Changed
+
+- **The library crates are named after the project**: `emeraldian-core`,
+  `emeraldian-theme` and `emeraldian-agent`, where they were `otui-*`. They are
+  about to go on crates.io, and a crate name cannot be changed or reclaimed once
+  it is taken, so this was cheap now and impossible later.
+- Two things deliberately kept their old names. Thread names read
+  `emerald-agent` rather than `emeraldian-agent`, because Linux caps a thread
+  name at 15 bytes and refuses anything longer, which would have left those
+  threads nameless in a debugger. And `OTUI_BIN_DIR`, `OTUI_VERSION`,
+  `OTUI_STATE_FILE` and `OTUI_CA_BUNDLE` keep their prefix, because they may
+  already be exported in someone's shell profile and renaming them would not
+  fail loudly, it would quietly ignore what they had set.
+
+### Added
+
+- The crates carry the metadata crates.io displays: repository, homepage,
+  keywords and categories. They had none, and a published version is immutable.
+- `.github/workflows/crates-io.yml`, publishing on a release tag through OIDC
+  trusted publishing rather than a stored token.
+
 ## [0.4.0] — 2026-08-07
 
 The release that renames the project. A minor bump rather than a patch: the
@@ -406,6 +431,7 @@ First release.
 - Unreadable vaults are reported clearly, including the macOS privacy
   permission that usually causes it.
 
+[0.4.1]: https://github.com/iamrohithrnair/emeraldian/releases/tag/v0.4.1
 [0.4.0]: https://github.com/iamrohithrnair/emeraldian/releases/tag/v0.4.0
 [0.3.1]: https://github.com/iamrohithrnair/emeraldian/releases/tag/v0.3.1
 [0.3.0]: https://github.com/iamrohithrnair/emeraldian/releases/tag/v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "emeraldian"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "emeraldian-agent"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "emeraldian-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "emeraldian-theme"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ratatui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/emeraldian-core", "crates/emeraldian-theme", "crates/emeraldian-agent", "crates/emeraldian"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 # Set by the dependency chain, not by this code: ratatui-image pulls
 # icy_sixel, which pins quantette 0.5.1, which requires 1.90.
@@ -19,9 +19,9 @@ keywords = ["obsidian", "tui", "notes", "markdown", "graph"]
 categories = ["command-line-utilities", "text-editors"]
 
 [workspace.dependencies]
-emeraldian-core = { path = "crates/emeraldian-core", version = "0.4.0" }
-emeraldian-theme = { path = "crates/emeraldian-theme", version = "0.4.0" }
-emeraldian-agent = { path = "crates/emeraldian-agent", version = "0.4.0" }
+emeraldian-core = { path = "crates/emeraldian-core", version = "0.4.1" }
+emeraldian-theme = { path = "crates/emeraldian-theme", version = "0.4.1" }
+emeraldian-agent = { path = "crates/emeraldian-agent", version = "0.4.1" }
 
 ratatui = "0.30"
 crossterm = "0.29"


### PR DESCRIPTION
Version bump for the crate rename and crates.io metadata in #14.

A patch rather than a minor: the renamed crates have never been published, so
nobody can be depending on them, and the binary behaves exactly as it did in
0.4.0.

- Workspace version and the three path dependencies to `0.4.1`
- `Cargo.lock` regenerated, `--locked` build verified
- CHANGELOG entry, including the two things that deliberately kept their old
  names and why

Once merged this gets tagged, but the four crates are published by hand first.
The workflow's skip-if-already-published check then makes the tagged run a
no-op for crates.io rather than a failure, since trusted publishing cannot be
configured until the crates exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)