### PR TITLE
Skip crates.io auth when there is nothing to publish

### DIFF
--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -62,28 +62,51 @@ jobs:
           fi
           echo "VERSION=$manifest" >> "$GITHUB_ENV"
 
-      - uses: rust-lang/crates-io-auth-action@v1
-        id: auth
-
-      - name: Publish, dependencies before dependents
+      - name: Work out whether anything needs publishing
+        id: needed
         shell: bash
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -euo pipefail
-          # emeraldian depends on the other three, so it goes last. crates.io
-          # rejects a crate whose dependencies it has never seen.
           # crates.io rejects requests without a User-Agent with a 403, which
           # `curl -f` reports the same way as a 404. Sending one is the
           # difference between "already published" and "always publish".
           ua="emeraldian-release (https://github.com/iamrohithrnair/emeraldian)"
-
+          todo=""
           for crate in emeraldian-core emeraldian-theme emeraldian-agent emeraldian; do
             if curl -sfo /dev/null -A "$ua" "https://crates.io/api/v1/crates/${crate}/${VERSION}"; then
-              # Versions are immutable, so a re-run must skip rather than fail.
               echo "${crate} ${VERSION} is already published"
-              continue
+            else
+              todo="${todo} ${crate}"
             fi
+          done
+          echo "crates=${todo# }" >> "$GITHUB_OUTPUT"
+          if [ -z "$todo" ]; then
+            echo "nothing to publish"
+            echo "any=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "any=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Authenticating is itself a failure when no trusted publisher is
+      # configured yet, so it has to sit behind the check rather than in front
+      # of it. Otherwise a release with nothing left to publish fails on the
+      # step that was only ever there to enable the work being skipped.
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+        if: steps.needed.outputs.any == 'true'
+
+      - name: Publish, dependencies before dependents
+        if: steps.needed.outputs.any == 'true'
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          CRATES: ${{ steps.needed.outputs.crates }}
+        run: |
+          set -euo pipefail
+          # The list is already in dependency order: emeraldian depends on the
+          # other three, and crates.io rejects a crate whose dependencies it has
+          # never seen.
+          for crate in $CRATES; do
             echo "publishing ${crate} ${VERSION}"
             cargo publish -p "${crate}"
           done

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://raw.githubusercontent.com/iamrohithrnair/emeraldian/main/docs/logo.png" width="84" alt="">
 
-# emeraldian
+# Emeraldian
 
 **The best TUI for Obsidian.** Your vault, the way you already know it: the
 three-pane layout, live-preview Markdown, backlinks, a force-directed graph,
@@ -47,7 +47,7 @@ worse than one that is plainly missing.
 **Cargo** (needs Rust 1.90 or newer):
 
 ```sh
-cargo install --git https://github.com/iamrohithrnair/emeraldian emeraldian
+cargo install emeraldian
 ```
 
 **Manual download.** Grab an archive from the
@@ -81,7 +81,7 @@ emeraldian                   # the vault Obsidian last had open
 emeraldian --list-vaults     # what Obsidian knows about
 ```
 
-emeraldian accepts ordinary flags and the `obsidian://` URIs the desktop app
+Emeraldian accepts ordinary flags and the `obsidian://` URIs the desktop app
 registers, so a link or script that opens Obsidian also opens this:
 
 ```sh
@@ -105,7 +105,7 @@ Settings → General → "Command line interface". The two do different jobs:
 | On a machine with no display | needs `--ozone-platform=headless` or Xvfb | runs as it is |
 
 So they complement each other rather than compete. When the `obsidian` binary is
-on your `PATH`, emeraldian uses it for the one thing only the app can do,
+on your `PATH`, Emeraldian uses it for the one thing only the app can do,
 which is handing a note to the GUI:
 
 - `/obsidian` in the assistant panel reports the CLI's status and the vaults the
@@ -113,7 +113,7 @@ which is handing a note to the GUI:
 - `/obsidian open`, or "Open this note in Obsidian" in the command palette,
   opens the current note in the desktop app.
 
-If the CLI isn't enabled, or Obsidian isn't running, emeraldian says so and
+If the CLI isn't enabled, or Obsidian isn't running, Emeraldian says so and
 carries on; nothing else depends on it.
 
 ## Keys
@@ -293,7 +293,7 @@ vault stays a plain folder of Markdown.
 
 ## Privacy
 
-**emeraldian makes no network connections unless you use the assistant.**
+**Emeraldian makes no network connections unless you use the assistant.**
 There is no telemetry, no analytics and no update check. Only the `emeraldian-agent`
 crate has an HTTP dependency at all; the vault, editor and graph cannot reach
 the network.
@@ -478,7 +478,7 @@ git push origin v0.3.0
 ## Credits
 
 This project exists because four other people published their work first. None
-of their code is in here (emeraldian is written from scratch), but every one
+of their code is in here (Emeraldian is written from scratch), but every one
 of them showed me something I'd otherwise have had to guess at, and the good
 ideas are theirs.
 
@@ -515,7 +515,7 @@ GPL anyway. The debt is one of ideas, and it's a real one.
 
 ## Trademark
 
-emeraldian is an independent, community-made tool. It is not affiliated with,
+Emeraldian is an independent, community-made tool. It is not affiliated with,
 endorsed by, or sponsored by Obsidian or Dynalist Inc. Obsidian is a trademark
 of Dynalist Inc., used here only to describe what this tool works with.
 
@@ -523,7 +523,7 @@ of Dynalist Inc., used here only to describe what this tool works with.
 
 Copyright (C) 2026 Rohith Nair.
 
-emeraldian is free software: you can redistribute it and/or modify it under
+Emeraldian is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software
 Foundation, either version 3 of the License, or (at your option) any later
 version. See [LICENSE](LICENSE).

--- a/docs/index.html
+++ b/docs/index.html
@@ -599,8 +599,8 @@
       </div>
 
       <div role="tabpanel" id="p-cargo" aria-labelledby="t-cargo" class="panel" tabindex="0" hidden>
-        <button class="copy-cmd wide" data-copy="cargo install --git https://github.com/iamrohithrnair/emeraldian emeraldian">
-          <span class="sigil" aria-hidden="true">$</span><code>cargo install --git https://github.com/iamrohithrnair/emeraldian emeraldian</code>
+        <button class="copy-cmd wide" data-copy="cargo install emeraldian">
+          <span class="sigil" aria-hidden="true">$</span><code>cargo install emeraldian</code>
           <span class="copy-icon" aria-hidden="true"><svg viewBox="0 0 20 20" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="10" height="10" rx="2"/><path d="M13 4.5H5A1.5 1.5 0 0 0 3.5 6v8"/></svg></span>
         </button>
         <p class="panel-note">Needs Rust 1.88 or newer. This is also the route for Intel Macs, which build from source.</p>


### PR DESCRIPTION
Tagging `v0.4.1` turned the crates.io job red:

```
Failed to retrieve token from Cargo registry. Status: 400.
Error: No Trusted Publishing config found for repository `iamrohithrnair/emeraldian`.
```

## What went wrong

I predicted this run would skip, because #14 added an already-published check
so a re-run would be a no-op. It didn't, and the reason is ordering: that check
sat **after** `crates-io-auth-action`. Authentication is itself a failure until
a trusted publisher is configured, and a trusted publisher cannot be configured
until the crates exist. So the first tagged release was always going to fail on
the step that existed only to enable work already done.

## Fix

The check runs first and produces the list of crates that actually need
publishing. Both the auth step and the publish step are conditional on that
list being non-empty, and the publish loop consumes the list rather than
re-deriving it.

Verified against the live registry: with all four crates at 0.4.1 published,
the check yields `any=false`, so auth and publish are both skipped and the job
is green. Against a version that does not exist, it correctly lists the crates
to publish.

## Also

All four crates are now on crates.io, so the install instructions point at the
registry instead of a git URL:

```sh
cargo install emeraldian
```

Verified end to end with a real `cargo install emeraldian` from a clean root.

The README title and prose now read **Emeraldian**. Commands, config paths and
crate names stay lowercase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)