### PR TITLE
Release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] — 2026-08-07
+
+Nothing in the app changed. This release exists to carry the packaging work,
+and to prove that the release pipeline itself works end to end.
+
+### Added
+
+- `cargo install emeraldian` now works, without a git URL. All four crates are
+  on crates.io, so the site and the README point at the registry.
+- The crates.io workflow can be run by hand with `verify_only` to check that
+  trusted publishing is still configured correctly, without publishing
+  anything. Worth doing after renaming this repository or the workflow file,
+  since either invalidates the trusted publisher silently.
+
+### Fixed
+
+- **The Homebrew tap is updated by the release, rather than only appearing to
+  be.** The step guarded on `git diff`, which reports tracked files only, so a
+  formula the tap had never held read as no change at all and was never
+  committed. The job reported success on every release from the first one
+  onwards while the tap stayed empty, which is why `brew install` had never
+  worked.
+- Tagging a release no longer fails when every crate is already published. The
+  check that made a re-run a no-op sat after authentication, and authenticating
+  is itself a failure until a trusted publisher exists.
+
 ## [0.4.1] — 2026-08-07
 
 A packaging release. Nothing about using the app has changed.
@@ -431,6 +457,7 @@ First release.
 - Unreadable vaults are reported clearly, including the macOS privacy
   permission that usually causes it.
 
+[0.4.2]: https://github.com/iamrohithrnair/emeraldian/releases/tag/v0.4.2
 [0.4.1]: https://github.com/iamrohithrnair/emeraldian/releases/tag/v0.4.1
 [0.4.0]: https://github.com/iamrohithrnair/emeraldian/releases/tag/v0.4.0
 [0.3.1]: https://github.com/iamrohithrnair/emeraldian/releases/tag/v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "emeraldian"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "emeraldian-agent"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "emeraldian-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "emeraldian-theme"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ratatui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/emeraldian-core", "crates/emeraldian-theme", "crates/emeraldian-agent", "crates/emeraldian"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 # Set by the dependency chain, not by this code: ratatui-image pulls
 # icy_sixel, which pins quantette 0.5.1, which requires 1.90.
@@ -19,9 +19,9 @@ keywords = ["obsidian", "tui", "notes", "markdown", "graph"]
 categories = ["command-line-utilities", "text-editors"]
 
 [workspace.dependencies]
-emeraldian-core = { path = "crates/emeraldian-core", version = "0.4.1" }
-emeraldian-theme = { path = "crates/emeraldian-theme", version = "0.4.1" }
-emeraldian-agent = { path = "crates/emeraldian-agent", version = "0.4.1" }
+emeraldian-core = { path = "crates/emeraldian-core", version = "0.4.2" }
+emeraldian-theme = { path = "crates/emeraldian-theme", version = "0.4.2" }
+emeraldian-agent = { path = "crates/emeraldian-agent", version = "0.4.2" }
 
 ratatui = "0.30"
 crossterm = "0.29"


### PR DESCRIPTION
No change to the app. This release carries the packaging work and exercises the
release pipeline end to end for the first time.

Trusted publishing was verified before cutting this, using the `verify_only`
mode added in #17:

```
success  Run rust-lang/crates-io-auth-action@v1
success  Report that trusted publishing works
skipped  Publish, dependencies before dependents
```

So the OIDC exchange is known good. With the API token now revoked, this tag is
the first release that *must* go through it.

## What to watch on the tag

- **crates.io** — all four crates are unpublished at 0.4.2, so the check yields
  `any=true`, auth runs for real, and the four publish in dependency order
- **Homebrew** — should update the tap to 0.4.2 by itself, as it did for 0.4.1
- **npm** — will report success and do nothing, as it has since launch. No
  `NPM_TOKEN`, and that route needs its own manual bootstrap

## Verified locally

`cargo build --release --locked`, 612 tests, binary reports `emeraldian 0.4.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)